### PR TITLE
Add Notes about Unavailable Interfaces

### DIFF
--- a/docs/TTS/IsReady/index.md
+++ b/docs/TTS/IsReady/index.md
@@ -11,12 +11,26 @@ Purpose
 
 ### Request
 
+!!! note
+
+1. SDL sends `VR.IsReady` request after HMI confirms its readiness via `BC.OnREady` notification.
+2. If HMI responds with `"available":false`, SDL will not further communicate over VR interface with HMI.
+3. If HMI does not respond during SDL's default timeout, SDL will continue to send RPCs over VR interface to HMI.
+
+!!!
+
 #### Parameters
 
-|Name|Type|Mandatory|Additional|
-|:---|:---|:--------|:---------|
+The request does not have specific parameters.
 
 ### Response
+
+!!! must
+
+1. Check whether UI component is available and ready.
+2. Respond correspondingly to results of this check.
+
+!!!
 
 #### Parameters
 

--- a/docs/TTS/IsReady/index.md
+++ b/docs/TTS/IsReady/index.md
@@ -13,9 +13,9 @@ Purpose
 
 !!! note
 
-1. SDL sends `VR.IsReady` request after HMI confirms its readiness via `BC.OnREady` notification.
-2. If HMI responds with `"available":false`, SDL will not further communicate over VR interface with HMI.
-3. If HMI does not respond during SDL's default timeout, SDL will continue to send RPCs over VR interface to HMI.
+1. SDL sends `TTS.IsReady` request after HMI confirms its readiness via `BC.OnREady` notification.
+2. If HMI responds with `"available":false`, SDL will not further communicate over TTS interface with HMI.
+3. If HMI does not respond during SDL's default timeout, SDL will continue to send RPCs over TTS interface to HMI.
 
 !!!
 
@@ -27,7 +27,7 @@ The request does not have specific parameters.
 
 !!! must
 
-1. Check whether UI component is available and ready.
+1. Check whether TTS component is available and ready.
 2. Respond correspondingly to results of this check.
 
 !!!

--- a/docs/UI/IsReady/index.md
+++ b/docs/UI/IsReady/index.md
@@ -14,10 +14,24 @@ Purpose
 
 #### Parameters
 
-|Name|Type|Mandatory|Additional|
-|:---|:---|:--------|:---------|
+The request does not have specific parameters.
+
+!!! note
+
+1. SDL sends `UI.IsReady` request after HMI confirms its readiness via `BC.OnREady` notification.
+2. If HMI responds with `"available":false`, SDL will not further communicate over UI interface with HMI.
+3. If HMI does not respond during SDL's default timeout, SDL will continue to send RPCs over UI interface to HMI.
+
+!!!
 
 ### Response
+
+!!! must
+
+1. Check whether UI component is available and ready.
+2. Respond correspondingly to results of this check.
+
+!!!
 
 #### Parameters
 

--- a/docs/VR/IsReady/index.md
+++ b/docs/VR/IsReady/index.md
@@ -11,12 +11,26 @@ Purpose
 
 ### Request
 
+!!! note
+
+1. SDL sends `VR.IsReady` request after HMI confirms its readiness via `BC.OnREady` notification.
+2. If HMI responds with `"available":false`, SDL will not further communicate over VR interface with HMI.
+3. If HMI does not respond during SDL's default timeout, SDL will continue to send RPCs over VR interface to HMI.
+
+!!!
+
 #### Parameters
 
-|Name|Type|Mandatory|Additional|
-|:---|:---|:--------|:---------|
+The request does not have specific parameters.
 
 ### Response
+
+!!! must
+
+1. Check whether VR module is available and ready.
+2. Respond correspondingly to results of this check.
+
+!!!
 
 #### Parameters
 

--- a/docs/VehicleInfo/IsReady/index.md
+++ b/docs/VehicleInfo/IsReady/index.md
@@ -11,12 +11,26 @@ Purpose
 
 ### Request
 
+!!! note
+
+1. SDL sends `VehicleInfo.IsReady` request after HMI confirms its readiness via `BC.OnREady` notification.
+2. If HMI responds with `"available":false`, SDL will not further communicate over VehicleInfo interface with HMI.
+3. If HMI does not respond during SDL's default timeout, SDL will continue to send RPCs over VehicleInfo interface to HMI.
+
+!!!
+
 #### Parameters
 
-|Name|Type|Mandatory|Additional|
-|:---|:---|:--------|:---------|
+The request does not have specific parameters.
 
 ### Response
+
+!!! must
+
+1. Check whether VehicleInfo module is available and ready.
+2. Respond correspondingly to results of this check.
+
+!!!
 
 #### Parameters
 


### PR DESCRIPTION
Describe SDL behaviour in cases:
1. interface is not available: response IsReady(available: false)
2. interface availability is unknown: non-response
3. interface is available: response IsReady(available: true)

Impacted interfaces:
    UI
    TTS
    VR
    VehiclaeInfo

Note: Navigation interface already had this information.

related task: https://github.com/smartdevicelink/sdl_hmi_integration_guidelines/issues/20