### PR TITLE
Fix message type for StartStream and StartAudioStream

### DIFF
--- a/docs/Navigation/StartAudioStream/index.md
+++ b/docs/Navigation/StartAudioStream/index.md
@@ -1,7 +1,7 @@
 ## StartAudioStream
 
 Type
-: Notification
+: Request
 
 Sender
 : SDL

--- a/docs/Navigation/StartStream/index.md
+++ b/docs/Navigation/StartStream/index.md
@@ -1,7 +1,7 @@
 ## StartStream
 
 Type
-: Notification
+: Request
 
 Sender
 : SDL

--- a/docs/Navigation/StopAudioStream/index.md
+++ b/docs/Navigation/StopAudioStream/index.md
@@ -1,7 +1,7 @@
 ## StopAudioStream
 
 Type
-: Notification
+: Request
 
 Sender
 : SDL

--- a/docs/Navigation/StopStream/index.md
+++ b/docs/Navigation/StopStream/index.md
@@ -1,7 +1,7 @@
 ## StopStream
 
 Type
-: Notification
+: Request
 
 Sender
 : SDL


### PR DESCRIPTION

Fixes https://github.com/smartdevicelink/sdl_hmi_integration_guidelines/issues/144

This PR is **ready** for review.

### Summary
Change message type for StartStream and StartAudioStream from `Notification` to `Request`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
