### PR TITLE
Change sections in RPC documentation to follow one convention

### DIFF
--- a/docs/AppService/AppServiceActivation/index.md
+++ b/docs/AppService/AppServiceActivation/index.md
@@ -53,7 +53,7 @@ AppServiceActivation set default service
 ![AppServiceActivation](./assets/AppServiceActivation_SetAsDefault_Success.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -68,7 +68,7 @@ AppServiceActivation set default service
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -84,7 +84,7 @@ AppServiceActivation set default service
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/AppService/AppServiceActivation/index.md
+++ b/docs/AppService/AppServiceActivation/index.md
@@ -53,7 +53,9 @@ AppServiceActivation set default service
 ![AppServiceActivation](./assets/AppServiceActivation_SetAsDefault_Success.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -68,7 +70,7 @@ AppServiceActivation set default service
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -84,7 +86,7 @@ AppServiceActivation set default service
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/AppService/AppServiceActivation/index.md
+++ b/docs/AppService/AppServiceActivation/index.md
@@ -53,7 +53,7 @@ AppServiceActivation set default service
 ![AppServiceActivation](./assets/AppServiceActivation_SetAsDefault_Success.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -68,7 +68,7 @@ AppServiceActivation set default service
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -84,7 +84,7 @@ AppServiceActivation set default service
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/AppService/GetActiveServiceConsent/index.md
+++ b/docs/AppService/GetActiveServiceConsent/index.md
@@ -41,7 +41,9 @@ GetActiveServiceConsent (user rejects prompt)
 ![GetActiveServiceConsent](./assets/GetActiveServiceConsent_Reject.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -54,7 +56,7 @@ GetActiveServiceConsent (user rejects prompt)
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -68,7 +70,7 @@ GetActiveServiceConsent (user rejects prompt)
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/AppService/GetActiveServiceConsent/index.md
+++ b/docs/AppService/GetActiveServiceConsent/index.md
@@ -41,7 +41,7 @@ GetActiveServiceConsent (user rejects prompt)
 ![GetActiveServiceConsent](./assets/GetActiveServiceConsent_Reject.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -54,7 +54,7 @@ GetActiveServiceConsent (user rejects prompt)
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -68,7 +68,7 @@ GetActiveServiceConsent (user rejects prompt)
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/AppService/GetActiveServiceConsent/index.md
+++ b/docs/AppService/GetActiveServiceConsent/index.md
@@ -41,7 +41,7 @@ GetActiveServiceConsent (user rejects prompt)
 ![GetActiveServiceConsent](./assets/GetActiveServiceConsent_Reject.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -54,7 +54,7 @@ GetActiveServiceConsent (user rejects prompt)
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -68,7 +68,7 @@ GetActiveServiceConsent (user rejects prompt)
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/AppService/GetAppServiceData/index.md
+++ b/docs/AppService/GetAppServiceData/index.md
@@ -43,7 +43,7 @@ GetAppServiceData (HMI Consumer)
 ![GetAppServiceData_HMI_ASC](./assets/GetAppServiceData_HMI_ASC.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -55,7 +55,8 @@ GetAppServiceData (HMI Consumer)
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -86,7 +87,8 @@ GetAppServiceData (HMI Consumer)
   }
 }
 ```
-### Example Error
+
+### JSON Example Error
 
 ```json
 {

--- a/docs/AppService/GetAppServiceData/index.md
+++ b/docs/AppService/GetAppServiceData/index.md
@@ -43,7 +43,9 @@ GetAppServiceData (HMI Consumer)
 ![GetAppServiceData_HMI_ASC](./assets/GetAppServiceData_HMI_ASC.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -56,7 +58,7 @@ GetAppServiceData (HMI Consumer)
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -88,7 +90,7 @@ GetAppServiceData (HMI Consumer)
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/AppService/GetAppServiceData/index.md
+++ b/docs/AppService/GetAppServiceData/index.md
@@ -43,7 +43,7 @@ GetAppServiceData (HMI Consumer)
 ![GetAppServiceData_HMI_ASC](./assets/GetAppServiceData_HMI_ASC.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -56,7 +56,7 @@ GetAppServiceData (HMI Consumer)
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -88,7 +88,7 @@ GetAppServiceData (HMI Consumer)
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/AppService/GetAppServiceRecords/index.md
+++ b/docs/AppService/GetAppServiceRecords/index.md
@@ -38,7 +38,7 @@ GetAppServiceRecords
 ![GetAppServiceRecords](./assets/GetAppServiceRecords.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -51,7 +51,7 @@ GetAppServiceRecords
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -92,6 +92,24 @@ GetAppServiceRecords
         "servicePublished": true
       }
     ]
+  }
+}
+```
+
+### JSON Example Error
+
+```json
+{
+  "id" : 176,
+  "jsonrpc" : "2.0",
+  "error" :
+  {
+    "code" : 22,
+    "message" : "Request timeout",
+    "data" :
+    {
+      "method" : "AppService.GetAppServiceRecords"
+    }
   }
 }
 ```

--- a/docs/AppService/GetAppServiceRecords/index.md
+++ b/docs/AppService/GetAppServiceRecords/index.md
@@ -38,7 +38,7 @@ GetAppServiceRecords
 ![GetAppServiceRecords](./assets/GetAppServiceRecords.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -51,7 +51,7 @@ GetAppServiceRecords
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -96,7 +96,7 @@ GetAppServiceRecords
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/AppService/GetAppServiceRecords/index.md
+++ b/docs/AppService/GetAppServiceRecords/index.md
@@ -38,7 +38,9 @@ GetAppServiceRecords
 ![GetAppServiceRecords](./assets/GetAppServiceRecords.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -51,7 +53,7 @@ GetAppServiceRecords
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -96,7 +98,7 @@ GetAppServiceRecords
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/AppService/OnAppServiceData/index.md
+++ b/docs/AppService/OnAppServiceData/index.md
@@ -35,7 +35,7 @@ OnAppServiceData (HMI Consumer)
 ![OnAppServiceData_HMI_ASC](./assets/OnAppServiceData_HMI_ASC.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 
 ```json
 {

--- a/docs/AppService/OnAppServiceData/index.md
+++ b/docs/AppService/OnAppServiceData/index.md
@@ -35,7 +35,7 @@ OnAppServiceData (HMI Consumer)
 ![OnAppServiceData_HMI_ASC](./assets/OnAppServiceData_HMI_ASC.png)
 |||
 
-### Example Notification
+### JSON Example Notification
 
 ```json
 {

--- a/docs/AppService/OnAppServiceData/index.md
+++ b/docs/AppService/OnAppServiceData/index.md
@@ -35,7 +35,9 @@ OnAppServiceData (HMI Consumer)
 ![OnAppServiceData_HMI_ASC](./assets/OnAppServiceData_HMI_ASC.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 
 ```json
 {

--- a/docs/AppService/PerformAppServiceInteraction/index.md
+++ b/docs/AppService/PerformAppServiceInteraction/index.md
@@ -48,7 +48,7 @@ PerformAppServiceInteraction with Mobile ASC
 ![PerformAppServiceInteraction](./assets/PerformAppServiceInteractionFromMobile.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -63,7 +63,7 @@ PerformAppServiceInteraction with Mobile ASC
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -77,7 +77,7 @@ PerformAppServiceInteraction with Mobile ASC
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/AppService/PerformAppServiceInteraction/index.md
+++ b/docs/AppService/PerformAppServiceInteraction/index.md
@@ -48,7 +48,9 @@ PerformAppServiceInteraction with Mobile ASC
 ![PerformAppServiceInteraction](./assets/PerformAppServiceInteractionFromMobile.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -63,7 +65,7 @@ PerformAppServiceInteraction with Mobile ASC
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -77,7 +79,7 @@ PerformAppServiceInteraction with Mobile ASC
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/AppService/PerformAppServiceInteraction/index.md
+++ b/docs/AppService/PerformAppServiceInteraction/index.md
@@ -48,7 +48,7 @@ PerformAppServiceInteraction with Mobile ASC
 ![PerformAppServiceInteraction](./assets/PerformAppServiceInteractionFromMobile.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -63,7 +63,7 @@ PerformAppServiceInteraction with Mobile ASC
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -77,7 +77,7 @@ PerformAppServiceInteraction with Mobile ASC
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/AppService/PublishAppService/index.md
+++ b/docs/AppService/PublishAppService/index.md
@@ -38,7 +38,7 @@ PublishAppService
 ![PublishAppService](./assets/PublishAppService.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -60,7 +60,7 @@ PublishAppService
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -88,7 +88,7 @@ PublishAppService
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/AppService/PublishAppService/index.md
+++ b/docs/AppService/PublishAppService/index.md
@@ -38,7 +38,7 @@ PublishAppService
 ![PublishAppService](./assets/PublishAppService.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -60,7 +60,7 @@ PublishAppService
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -84,6 +84,24 @@ PublishAppService
       },
       "code" : 0,
       "method" : "AppService.PublishAppService"
+  }
+}
+```
+
+### JSON Example Error
+
+```json
+{
+  "id" : 176,
+  "jsonrpc" : "2.0",
+  "error" :
+  {
+    "code" : 22,
+    "message" : "Request timeout",
+    "data" :
+    {
+      "method" : "AppService.PublishAppService"
+    }
   }
 }
 ```

--- a/docs/AppService/PublishAppService/index.md
+++ b/docs/AppService/PublishAppService/index.md
@@ -38,7 +38,9 @@ PublishAppService
 ![PublishAppService](./assets/PublishAppService.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -60,7 +62,7 @@ PublishAppService
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -88,7 +90,7 @@ PublishAppService
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/AppService/UnpublishAppService/index.md
+++ b/docs/AppService/UnpublishAppService/index.md
@@ -25,7 +25,9 @@ Purpose
 |:---|:---|:--------|:---------|
 |||||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -38,7 +40,7 @@ Purpose
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -51,7 +53,7 @@ Purpose
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/AppService/UnpublishAppService/index.md
+++ b/docs/AppService/UnpublishAppService/index.md
@@ -25,7 +25,7 @@ Purpose
 |:---|:---|:--------|:---------|
 |||||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -38,7 +38,7 @@ Purpose
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -48,5 +48,23 @@ Purpose
         "code" : 0,
         "method" : "AppService.UnpublishAppService"
     }
+}
+```
+
+### JSON Example Error
+
+```json
+{
+  "id" : 176,
+  "jsonrpc" : "2.0",
+  "error" :
+  {
+    "code" : 22,
+    "message" : "Request timeout",
+    "data" :
+    {
+      "method" : "AppService.UnpublishAppService"
+    }
+  }
 }
 ```

--- a/docs/AppService/UnpublishAppService/index.md
+++ b/docs/AppService/UnpublishAppService/index.md
@@ -25,7 +25,7 @@ Purpose
 |:---|:---|:--------|:---------|
 |||||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -38,7 +38,7 @@ Purpose
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -51,7 +51,7 @@ Purpose
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/ActivateApp/index.md
+++ b/docs/BasicCommunication/ActivateApp/index.md
@@ -62,7 +62,7 @@ If `level` is `FULL` or `LIMITED`:
 
 This RPC has no additional parameter requirements
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -75,7 +75,8 @@ This RPC has no additional parameter requirements
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -89,7 +90,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/ActivateApp/index.md
+++ b/docs/BasicCommunication/ActivateApp/index.md
@@ -62,7 +62,7 @@ If `level` is `FULL` or `LIMITED`:
 
 This RPC has no additional parameter requirements
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -76,7 +76,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -90,7 +90,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/ActivateApp/index.md
+++ b/docs/BasicCommunication/ActivateApp/index.md
@@ -62,6 +62,24 @@ If `level` is `FULL` or `LIMITED`:
 
 This RPC has no additional parameter requirements
 
+### Sequence Diagrams
+|||
+Activate App after successful Resumption
+![Activate App Successful Resume](./assets/ActivateAppSuccessfulResume.png)
+|||
+|||
+Activate App after failed Resumption
+![Activate App Failed Resume](./assets/ActivateAppFailedResume.png)
+|||
+|||
+Activate App after Unexpected Disconnect
+![Activate App Unexpected Disconnect](./assets/ActivateAppUnexpectedDisconnect.png)
+|||
+|||
+Activate App after Accepted Data Consent Prompt
+![Activate App Successful Data](./assets/ActivateAppSuccessfulData.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Request
@@ -110,20 +128,3 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Sequence Diagrams
-|||
-Activate App after successful Resumption
-![Activate App Successful Resume](./assets/ActivateAppSuccessfulResume.png)
-|||
-|||
-Activate App after failed Resumption
-![Activate App Failed Resume](./assets/ActivateAppFailedResume.png)
-|||
-|||
-Activate App after Unexpected Disconnect
-![Activate App Unexpected Disconnect](./assets/ActivateAppUnexpectedDisconnect.png)
-|||
-|||
-Activate App after Accepted Data Consent Prompt
-![Activate App Successful Data](./assets/ActivateAppSuccessfulData.png)
-|||

--- a/docs/BasicCommunication/ActivateApp/index.md
+++ b/docs/BasicCommunication/ActivateApp/index.md
@@ -62,7 +62,9 @@ If `level` is `FULL` or `LIMITED`:
 
 This RPC has no additional parameter requirements
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -76,7 +78,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -90,7 +92,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/CloseApplication/index.md
+++ b/docs/BasicCommunication/CloseApplication/index.md
@@ -36,6 +36,16 @@ SDL will:
 
 This RPC has no additional parameter requirements
 
+### Sequence Diagrams
+|||
+Close Application request from mobile application
+![Close Application request from Mobile](./assets/CloseApplicationFromMobile.png)
+|||
+|||
+Close Application after Failed Data Consent Prompt
+![Close Application Failed Data](./assets/CloseApplicationFailedData.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Request
@@ -83,13 +93,3 @@ This RPC has no additional parameter requirements
   }
 }
 ```
-
-### Sequence Diagrams
-|||
-Close Application request from mobile application
-![Close Application request from Mobile](./assets/CloseApplicationFromMobile.png)
-|||
-|||
-Close Application after Failed Data Consent Prompt
-![Close Application Failed Data](./assets/CloseApplicationFailedData.png)
-|||

--- a/docs/BasicCommunication/CloseApplication/index.md
+++ b/docs/BasicCommunication/CloseApplication/index.md
@@ -36,7 +36,7 @@ SDL will:
 
 This RPC has no additional parameter requirements
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -50,7 +50,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -64,7 +64,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/CloseApplication/index.md
+++ b/docs/BasicCommunication/CloseApplication/index.md
@@ -36,7 +36,9 @@ SDL will:
 
 This RPC has no additional parameter requirements
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -50,7 +52,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -64,7 +66,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/CloseApplication/index.md
+++ b/docs/BasicCommunication/CloseApplication/index.md
@@ -36,7 +36,7 @@ SDL will:
 
 This RPC has no additional parameter requirements
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -49,7 +49,8 @@ This RPC has no additional parameter requirements
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -63,7 +64,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/DecryptCertificate/index.md
+++ b/docs/BasicCommunication/DecryptCertificate/index.md
@@ -34,7 +34,7 @@ DecryptCertificate
 ![DecryptCertificate](assets/DecryptCertificate.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -47,7 +47,7 @@ DecryptCertificate
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -60,7 +60,7 @@ DecryptCertificate
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/DecryptCertificate/index.md
+++ b/docs/BasicCommunication/DecryptCertificate/index.md
@@ -34,7 +34,7 @@ DecryptCertificate
 ![DecryptCertificate](assets/DecryptCertificate.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -47,7 +47,7 @@ DecryptCertificate
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -60,7 +60,7 @@ DecryptCertificate
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/DecryptCertificate/index.md
+++ b/docs/BasicCommunication/DecryptCertificate/index.md
@@ -34,7 +34,9 @@ DecryptCertificate
 ![DecryptCertificate](assets/DecryptCertificate.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -47,7 +49,7 @@ DecryptCertificate
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -60,7 +62,7 @@ DecryptCertificate
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/DialNumber/index.md
+++ b/docs/BasicCommunication/DialNumber/index.md
@@ -57,7 +57,9 @@ DialNumber Failed
 ![DialNumberFailed](./assets/DialNumberFailed.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -71,7 +73,7 @@ DialNumber Failed
   }
 }
 ```
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -85,7 +87,7 @@ DialNumber Failed
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/DialNumber/index.md
+++ b/docs/BasicCommunication/DialNumber/index.md
@@ -57,7 +57,7 @@ DialNumber Failed
 ![DialNumberFailed](./assets/DialNumberFailed.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -71,7 +71,7 @@ DialNumber Failed
   }
 }
 ```
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -85,7 +85,7 @@ DialNumber Failed
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/DialNumber/index.md
+++ b/docs/BasicCommunication/DialNumber/index.md
@@ -57,7 +57,7 @@ DialNumber Failed
 ![DialNumberFailed](./assets/DialNumberFailed.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -71,7 +71,7 @@ DialNumber Failed
   }
 }
 ```
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -85,7 +85,7 @@ DialNumber Failed
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/GetFilePath/index.md
+++ b/docs/BasicCommunication/GetFilePath/index.md
@@ -35,7 +35,7 @@ GetFile (HMI Provider)
 ![GetFile](./assets/GetFile.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -50,7 +50,7 @@ GetFile (HMI Provider)
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -64,7 +64,8 @@ GetFile (HMI Provider)
 	}
 }
 ```
-### Example Error
+
+### JSON Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/GetFilePath/index.md
+++ b/docs/BasicCommunication/GetFilePath/index.md
@@ -35,7 +35,7 @@ GetFile (HMI Provider)
 ![GetFile](./assets/GetFile.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -50,7 +50,7 @@ GetFile (HMI Provider)
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -65,7 +65,7 @@ GetFile (HMI Provider)
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/GetFilePath/index.md
+++ b/docs/BasicCommunication/GetFilePath/index.md
@@ -35,7 +35,9 @@ GetFile (HMI Provider)
 ![GetFile](./assets/GetFile.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -50,7 +52,7 @@ GetFile (HMI Provider)
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -65,7 +67,7 @@ GetFile (HMI Provider)
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/GetSystemInfo/index.md
+++ b/docs/BasicCommunication/GetSystemInfo/index.md
@@ -37,7 +37,9 @@ This RPC has no additional parameter requirements.
 |language|[Common.Language](../../common/enums/#language)|true||
 |wersCountryCode|String|true|maxlength: 500|
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -47,7 +49,7 @@ This RPC has no additional parameter requirements.
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -65,7 +67,7 @@ This RPC has no additional parameter requirements.
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/GetSystemInfo/index.md
+++ b/docs/BasicCommunication/GetSystemInfo/index.md
@@ -37,6 +37,12 @@ This RPC has no additional parameter requirements.
 |language|[Common.Language](../../common/enums/#language)|true||
 |wersCountryCode|String|true|maxlength: 500|
 
+### Sequence Diagrams
+|||
+GetSystemInfo
+![GetSysteminfo](./assets/GetSystemInfo.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Request
@@ -84,9 +90,3 @@ This RPC has no additional parameter requirements.
   }
 }
 ```
-
-### Sequence Diagrams
-|||
-GetSystemInfo
-![GetSysteminfo](./assets/GetSystemInfo.png)
-|||

--- a/docs/BasicCommunication/GetSystemInfo/index.md
+++ b/docs/BasicCommunication/GetSystemInfo/index.md
@@ -37,7 +37,7 @@ This RPC has no additional parameter requirements.
 |language|[Common.Language](../../common/enums/#language)|true||
 |wersCountryCode|String|true|maxlength: 500|
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -47,7 +47,7 @@ This RPC has no additional parameter requirements.
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -65,7 +65,7 @@ This RPC has no additional parameter requirements.
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/GetSystemInfo/index.md
+++ b/docs/BasicCommunication/GetSystemInfo/index.md
@@ -37,7 +37,7 @@ This RPC has no additional parameter requirements.
 |language|[Common.Language](../../common/enums/#language)|true||
 |wersCountryCode|String|true|maxlength: 500|
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -47,7 +47,7 @@ This RPC has no additional parameter requirements.
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -65,7 +65,7 @@ This RPC has no additional parameter requirements.
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/GetSystemTime/index.md
+++ b/docs/BasicCommunication/GetSystemTime/index.md
@@ -56,7 +56,7 @@ GetSystemTime
 |||
 
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -66,7 +66,7 @@ GetSystemTime
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {  
@@ -92,7 +92,7 @@ GetSystemTime
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {  

--- a/docs/BasicCommunication/GetSystemTime/index.md
+++ b/docs/BasicCommunication/GetSystemTime/index.md
@@ -56,7 +56,7 @@ GetSystemTime
 |||
 
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -66,7 +66,7 @@ GetSystemTime
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {  
@@ -92,7 +92,7 @@ GetSystemTime
 }
 ```
 
-### Example Error  
+### JSON Example Error
 
 ```json
 {  

--- a/docs/BasicCommunication/GetSystemTime/index.md
+++ b/docs/BasicCommunication/GetSystemTime/index.md
@@ -56,7 +56,9 @@ GetSystemTime
 |||
 
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -66,7 +68,7 @@ GetSystemTime
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {  
@@ -92,7 +94,7 @@ GetSystemTime
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {  

--- a/docs/BasicCommunication/MixingAudioSupported/index.md
+++ b/docs/BasicCommunication/MixingAudioSupported/index.md
@@ -37,7 +37,9 @@ This RPC has no additional parameter requirements.
 |:---|:---|:--------|:---------|
 |attenuatedSupported|Boolean|true||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -47,7 +49,7 @@ This RPC has no additional parameter requirements.
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -62,7 +64,7 @@ This RPC has no additional parameter requirements.
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/MixingAudioSupported/index.md
+++ b/docs/BasicCommunication/MixingAudioSupported/index.md
@@ -37,7 +37,7 @@ This RPC has no additional parameter requirements.
 |:---|:---|:--------|:---------|
 |attenuatedSupported|Boolean|true||
 
-### Request Example
+### JSON Example Request
 
 ```json
 {
@@ -47,7 +47,7 @@ This RPC has no additional parameter requirements.
 }
 ```
 
-### Response Example
+### JSON Example Response
 
 ```json
 {
@@ -62,7 +62,7 @@ This RPC has no additional parameter requirements.
 }
 ```
 
-### Error Example
+### JSON Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/MixingAudioSupported/index.md
+++ b/docs/BasicCommunication/MixingAudioSupported/index.md
@@ -37,6 +37,12 @@ This RPC has no additional parameter requirements.
 |:---|:---|:--------|:---------|
 |attenuatedSupported|Boolean|true||
 
+### Sequence Diagrams
+|||
+MixingAudioSupported Messaging
+![Mixing Audio Supported](./assets/MixingAudioSupported.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Request
@@ -81,9 +87,3 @@ This RPC has no additional parameter requirements.
   }
 }
 ```
-
-### Sequence Diagrams
-|||
-MixingAudioSupported Messaging
-![Mixing Audio Supported](./assets/MixingAudioSupported.png)
-|||

--- a/docs/BasicCommunication/MixingAudioSupported/index.md
+++ b/docs/BasicCommunication/MixingAudioSupported/index.md
@@ -37,7 +37,7 @@ This RPC has no additional parameter requirements.
 |:---|:---|:--------|:---------|
 |attenuatedSupported|Boolean|true||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -47,7 +47,7 @@ This RPC has no additional parameter requirements.
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -62,7 +62,7 @@ This RPC has no additional parameter requirements.
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/OnAppActivated/index.md
+++ b/docs/BasicCommunication/OnAppActivated/index.md
@@ -44,7 +44,7 @@ User Activates App
 ![OnAppActivated](./assets/OnAppActivated.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnAppActivated/index.md
+++ b/docs/BasicCommunication/OnAppActivated/index.md
@@ -44,7 +44,7 @@ User Activates App
 ![OnAppActivated](./assets/OnAppActivated.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnAppActivated/index.md
+++ b/docs/BasicCommunication/OnAppActivated/index.md
@@ -44,7 +44,9 @@ User Activates App
 ![OnAppActivated](./assets/OnAppActivated.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnAppDeactivated/index.md
+++ b/docs/BasicCommunication/OnAppDeactivated/index.md
@@ -39,7 +39,7 @@ User Switches Apps
 ![OnAppDeactivated](./assets/OnAppDeactivated.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnAppDeactivated/index.md
+++ b/docs/BasicCommunication/OnAppDeactivated/index.md
@@ -39,7 +39,7 @@ User Switches Apps
 ![OnAppDeactivated](./assets/OnAppDeactivated.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnAppDeactivated/index.md
+++ b/docs/BasicCommunication/OnAppDeactivated/index.md
@@ -39,7 +39,9 @@ User Switches Apps
 ![OnAppDeactivated](./assets/OnAppDeactivated.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnAppRegistered/index.md
+++ b/docs/BasicCommunication/OnAppRegistered/index.md
@@ -101,7 +101,7 @@ Running the same apps from multiple devices at the same time
 ![OnAppRegistered](./assets/OnAppRegisteredMultipleDevices.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
 	"jsonrpc": "2.0",
@@ -125,7 +125,7 @@ Running the same apps from multiple devices at the same time
 }
 ```
 
-#### Cloud App JSON Example Notification
+#### Cloud App Example Notification
 
 ```json
 {

--- a/docs/BasicCommunication/OnAppRegistered/index.md
+++ b/docs/BasicCommunication/OnAppRegistered/index.md
@@ -101,7 +101,9 @@ Running the same apps from multiple devices at the same time
 ![OnAppRegistered](./assets/OnAppRegisteredMultipleDevices.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
 	"jsonrpc": "2.0",

--- a/docs/BasicCommunication/OnAppRegistered/index.md
+++ b/docs/BasicCommunication/OnAppRegistered/index.md
@@ -101,7 +101,7 @@ Running the same apps from multiple devices at the same time
 ![OnAppRegistered](./assets/OnAppRegisteredMultipleDevices.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
 	"jsonrpc": "2.0",

--- a/docs/BasicCommunication/OnAppUnregistered/index.md
+++ b/docs/BasicCommunication/OnAppUnregistered/index.md
@@ -50,7 +50,7 @@ Active App Unregistered
 ![OnAppUnregistered](./assets/OnAppUnregistered.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnAppUnregistered/index.md
+++ b/docs/BasicCommunication/OnAppUnregistered/index.md
@@ -50,7 +50,7 @@ Active App Unregistered
 ![OnAppUnregistered](./assets/OnAppUnregistered.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnAppUnregistered/index.md
+++ b/docs/BasicCommunication/OnAppUnregistered/index.md
@@ -50,7 +50,9 @@ Active App Unregistered
 ![OnAppUnregistered](./assets/OnAppUnregistered.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnAwakeSDL/index.md
+++ b/docs/BasicCommunication/OnAwakeSDL/index.md
@@ -30,7 +30,7 @@ Wake SDL from Suspension
 ![OnAwakeSDL](./assets/OnAwakeSDL.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnAwakeSDL/index.md
+++ b/docs/BasicCommunication/OnAwakeSDL/index.md
@@ -30,7 +30,9 @@ Wake SDL from Suspension
 ![OnAwakeSDL](./assets/OnAwakeSDL.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnAwakeSDL/index.md
+++ b/docs/BasicCommunication/OnAwakeSDL/index.md
@@ -30,7 +30,7 @@ Wake SDL from Suspension
 ![OnAwakeSDL](./assets/OnAwakeSDL.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnDeviceChosen/index.md
+++ b/docs/BasicCommunication/OnDeviceChosen/index.md
@@ -32,7 +32,9 @@ The list of known devices is provided to the HMI in the [UpdateDeviceList](../Up
 |:---|:---|:--------|:---------|
 |deviceInfo|[Common.DeviceInfo](../../common/structs/#deviceinfo)|true||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnDeviceChosen/index.md
+++ b/docs/BasicCommunication/OnDeviceChosen/index.md
@@ -32,7 +32,7 @@ The list of known devices is provided to the HMI in the [UpdateDeviceList](../Up
 |:---|:---|:--------|:---------|
 |deviceInfo|[Common.DeviceInfo](../../common/structs/#deviceinfo)|true||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnDeviceChosen/index.md
+++ b/docs/BasicCommunication/OnDeviceChosen/index.md
@@ -32,7 +32,7 @@ The list of known devices is provided to the HMI in the [UpdateDeviceList](../Up
 |:---|:---|:--------|:---------|
 |deviceInfo|[Common.DeviceInfo](../../common/structs/#deviceinfo)|true||
 
-### Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnDeviceChosen/index.md
+++ b/docs/BasicCommunication/OnDeviceChosen/index.md
@@ -32,6 +32,12 @@ The list of known devices is provided to the HMI in the [UpdateDeviceList](../Up
 |:---|:---|:--------|:---------|
 |deviceInfo|[Common.DeviceInfo](../../common/structs/#deviceinfo)|true||
 
+### Sequence Diagrams
+|||
+OnDeviceChosen
+![OnDeviceChosen](./assets/OnDeviceChosen.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Notification
@@ -50,8 +56,3 @@ The list of known devices is provided to the HMI in the [UpdateDeviceList](../Up
 }
 ```
 
-### Sequence Diagrams
-|||
-OnDeviceChosen
-![OnDeviceChosen](./assets/OnDeviceChosen.png)
-|||

--- a/docs/BasicCommunication/OnEventChanged/index.md
+++ b/docs/BasicCommunication/OnEventChanged/index.md
@@ -172,7 +172,7 @@ Multiple apps activation during active embedded navigation or audio source
 ![OnEventChanged](./assets/Multiple_apps_activation_during_active_embedded_navigation_or_audio_source.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnEventChanged/index.md
+++ b/docs/BasicCommunication/OnEventChanged/index.md
@@ -13,7 +13,7 @@ SDL uses `OnEventChanged` notification to appropriately manage the hmiLevel and 
 
 ### Event Types
 
-##### PHONE_CALL
+#### PHONE_CALL
 
 !!! MUST
 1. Send notification with appropriate parameter value when active call on HMI has been started/ended.
@@ -34,7 +34,7 @@ Upon receiving `OnEventChanged(PHONE_CALL)`, SDL will:
 |true|Change the HMI state of all applications currently either in FULL or LIMITED to (BACKGROUND, NOT_AUDIBLE)|
 |false|Return applications to the same HMI state they had prior to the event|
 
-##### EMERGENCY_EVENT
+#### EMERGENCY_EVENT
 
 EMERGENCY_EVENT is an HMI-specific event used when "Emergency event" or "Rear view camera" are active. The main idea of this from the SDL<->HMI point of view is that navigation/audio streaming mustn't interfere with Rear Camera View mode. The HMI is responsible for managing audio/video data while EMERGENCY_EVENT is active.
 
@@ -53,7 +53,7 @@ Upon receiving `OnEventChanged(EMERGENCY_EVENT)`, SDL will:
 While the event is active, the app is not allowed to stream audio and it will not be heard by the user (due to other audio and/or system events blocking it).
 !!!
 
-##### DEACTIVATE_HMI
+#### DEACTIVATE_HMI
 
 !!! MUST
 1. Send notification with appropriate parameter value when all apps should be deactivated/restored.
@@ -71,7 +71,7 @@ Upon receiving `OnEventChanged(DEACTIVATE_HMI)`, SDL will:
 When this event is active, SDL **rejects** all app activation requests from the HMI.
 !!!
 
-##### AUDIO_SOURCE/EMBEDDED_NAVI
+#### AUDIO_SOURCE/EMBEDDED_NAVI
 
 !!! MUST
 1. Send notification to SDL with appropriate parameter value when embedded navigation or audio source is activated/deactivated.
@@ -97,7 +97,7 @@ When this event is active, SDL **rejects** all app activation requests from the 
     - If SDL receives `OnEventChanged(EMBEDDED_NAVI, isActive=true)`, SDL changes any media app in (LIMITED, AUDIBLE) to (LIMITED, ATTENUATED). After the EMBEDDED_NAVI event ends, SDL changes the media app's state to (LIMITED, AUDIBLE).
 !!!
 
-###### HMI Status of apps when `AUDIO_SOURCE` or `EMBEDDED_NAVI` event is activated
+##### HMI Status of apps when `AUDIO_SOURCE` or `EMBEDDED_NAVI` event is activated
 |appHMIType|Event|HMI State before|HMI State after|
 |:---------|:----|:---------------|:--------------|
 |Media|AUDIO_SOURCE|(FULL/LIMITED, AUDIBLE)|(BACKGROUND, NOT_AUDIBLE)|
@@ -107,7 +107,7 @@ When this event is active, SDL **rejects** all app activation requests from the 
 |Navigation|EMBEDDED_NAVI|(FULL/LIMITED, AUDIBLE)|(BACKGROUND, NOT_AUDIBLE)|
 |Non-media|EMBEDDED_NAVI|(FULL/LIMITED, AUDIBLE)|(BACKGROUND, NOT_AUDIBLE)|
 
-###### Activating apps during active `AUDIO_SOURCE` or `EMBEDDED_NAVI` event
+##### Activating apps during active `AUDIO_SOURCE` or `EMBEDDED_NAVI` event
 |appHMIType|Event|New HMI State|Keep event active|
 |:---------|:----|:------------|:----------------|
 |Media|AUDIO_SOURCE|(FULL, AUDIBLE)|false|
@@ -172,7 +172,9 @@ Multiple apps activation during active embedded navigation or audio source
 ![OnEventChanged](./assets/Multiple_apps_activation_during_active_embedded_navigation_or_audio_source.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnEventChanged/index.md
+++ b/docs/BasicCommunication/OnEventChanged/index.md
@@ -11,6 +11,8 @@ Purpose
 
 SDL uses `OnEventChanged` notification to appropriately manage the hmiLevel and audioStreamingState of each application during an active event.
 
+### Event Types
+
 ##### PHONE_CALL
 
 !!! MUST
@@ -95,7 +97,7 @@ When this event is active, SDL **rejects** all app activation requests from the 
     - If SDL receives `OnEventChanged(EMBEDDED_NAVI, isActive=true)`, SDL changes any media app in (LIMITED, AUDIBLE) to (LIMITED, ATTENUATED). After the EMBEDDED_NAVI event ends, SDL changes the media app's state to (LIMITED, AUDIBLE).
 !!!
 
-##### HMI Status of apps when `AUDIO_SOURCE` or `EMBEDDED_NAVI` event is activated
+###### HMI Status of apps when `AUDIO_SOURCE` or `EMBEDDED_NAVI` event is activated
 |appHMIType|Event|HMI State before|HMI State after|
 |:---------|:----|:---------------|:--------------|
 |Media|AUDIO_SOURCE|(FULL/LIMITED, AUDIBLE)|(BACKGROUND, NOT_AUDIBLE)|
@@ -105,7 +107,7 @@ When this event is active, SDL **rejects** all app activation requests from the 
 |Navigation|EMBEDDED_NAVI|(FULL/LIMITED, AUDIBLE)|(BACKGROUND, NOT_AUDIBLE)|
 |Non-media|EMBEDDED_NAVI|(FULL/LIMITED, AUDIBLE)|(BACKGROUND, NOT_AUDIBLE)|
 
-##### Activating apps during active `AUDIO_SOURCE` or `EMBEDDED_NAVI` event
+###### Activating apps during active `AUDIO_SOURCE` or `EMBEDDED_NAVI` event
 |appHMIType|Event|New HMI State|Keep event active|
 |:---------|:----|:------------|:----------------|
 |Media|AUDIO_SOURCE|(FULL, AUDIBLE)|false|
@@ -114,6 +116,8 @@ When this event is active, SDL **rejects** all app activation requests from the 
 |Media|EMBEDDED_NAVI|(FULL, AUDIBLE)|true|
 |Navigation|EMBEDDED_NAVI|(FULL, AUDIBLE)|false|
 |Non-media|EMBEDDED_NAVI|(FULL, NOT_AUDIBLE)|true|
+
+### Notification
 
 #### Parameters
 
@@ -168,7 +172,7 @@ Multiple apps activation during active embedded navigation or audio source
 ![OnEventChanged](./assets/Multiple_apps_activation_during_active_embedded_navigation_or_audio_source.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnExitAllApplications/index.md
+++ b/docs/BasicCommunication/OnExitAllApplications/index.md
@@ -39,7 +39,7 @@ Exit All Apps on Ignition Off
 ![OnExitAllApplications](./assets/OnExitAllApps.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnExitAllApplications/index.md
+++ b/docs/BasicCommunication/OnExitAllApplications/index.md
@@ -39,7 +39,7 @@ Exit All Apps on Ignition Off
 ![OnExitAllApplications](./assets/OnExitAllApps.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnExitAllApplications/index.md
+++ b/docs/BasicCommunication/OnExitAllApplications/index.md
@@ -39,7 +39,9 @@ Exit All Apps on Ignition Off
 ![OnExitAllApplications](./assets/OnExitAllApps.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnExitApplication/index.md
+++ b/docs/BasicCommunication/OnExitApplication/index.md
@@ -55,7 +55,7 @@ Application Not Authorized
 ![OnExitApplication](./assets/OnExitApplicationUnauth.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnExitApplication/index.md
+++ b/docs/BasicCommunication/OnExitApplication/index.md
@@ -55,7 +55,7 @@ Application Not Authorized
 ![OnExitApplication](./assets/OnExitApplicationUnauth.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnExitApplication/index.md
+++ b/docs/BasicCommunication/OnExitApplication/index.md
@@ -55,7 +55,9 @@ Application Not Authorized
 ![OnExitApplication](./assets/OnExitApplicationUnauth.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnFileRemoved/index.md
+++ b/docs/BasicCommunication/OnFileRemoved/index.md
@@ -40,7 +40,9 @@ File Removed from Head Unit
 ![OnFileRemoved](./assets/OnFileRemoved.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
 	"jsonrpc": "2.0",

--- a/docs/BasicCommunication/OnFileRemoved/index.md
+++ b/docs/BasicCommunication/OnFileRemoved/index.md
@@ -40,7 +40,7 @@ File Removed from Head Unit
 ![OnFileRemoved](./assets/OnFileRemoved.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
 	"jsonrpc": "2.0",

--- a/docs/BasicCommunication/OnFileRemoved/index.md
+++ b/docs/BasicCommunication/OnFileRemoved/index.md
@@ -40,7 +40,7 @@ File Removed from Head Unit
 ![OnFileRemoved](./assets/OnFileRemoved.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
 	"jsonrpc": "2.0",

--- a/docs/BasicCommunication/OnFindApplications/index.md
+++ b/docs/BasicCommunication/OnFindApplications/index.md
@@ -41,7 +41,7 @@ OnFindApplications after Device Chosen by User
 ![OnFindApplications](./assets/OnFindApplicationsDeviceChosen.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnFindApplications/index.md
+++ b/docs/BasicCommunication/OnFindApplications/index.md
@@ -41,7 +41,9 @@ OnFindApplications after Device Chosen by User
 ![OnFindApplications](./assets/OnFindApplicationsDeviceChosen.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnFindApplications/index.md
+++ b/docs/BasicCommunication/OnFindApplications/index.md
@@ -41,7 +41,7 @@ OnFindApplications after Device Chosen by User
 ![OnFindApplications](./assets/OnFindApplicationsDeviceChosen.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnIgnitionCycleOver/index.md
+++ b/docs/BasicCommunication/OnIgnitionCycleOver/index.md
@@ -29,7 +29,9 @@ Send `BC.OnIgnitionCycleOver` together with `BC.OnExitAllApplications(IGNITION_O
 
 This RPC has no additional parameter requirements
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
 	"jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnIgnitionCycleOver/index.md
+++ b/docs/BasicCommunication/OnIgnitionCycleOver/index.md
@@ -29,7 +29,7 @@ Send `BC.OnIgnitionCycleOver` together with `BC.OnExitAllApplications(IGNITION_O
 
 This RPC has no additional parameter requirements
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
 	"jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnIgnitionCycleOver/index.md
+++ b/docs/BasicCommunication/OnIgnitionCycleOver/index.md
@@ -29,6 +29,12 @@ Send `BC.OnIgnitionCycleOver` together with `BC.OnExitAllApplications(IGNITION_O
 
 This RPC has no additional parameter requirements
 
+### Sequence Diagrams
+|||
+OnIgnitionCycleOver in triggering a Policy Table Update flow
+![OnIgnitionCycleOver](./assets/OnIgnitionCycleOver_in_Proprietary_PTU_flow.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Notification
@@ -38,9 +44,3 @@ This RPC has no additional parameter requirements
 	"method" : "BasicCommunication.OnIgnitionCycleOver"
 }
 ```
-
-### Sequence Diagrams
-|||
-OnIgnitionCycleOver in triggering a Policy Table Update flow
-![OnIgnitionCycleOver](./assets/OnIgnitionCycleOver_in_Proprietary_PTU_flow.png)
-|||

--- a/docs/BasicCommunication/OnIgnitionCycleOver/index.md
+++ b/docs/BasicCommunication/OnIgnitionCycleOver/index.md
@@ -29,7 +29,7 @@ Send `BC.OnIgnitionCycleOver` together with `BC.OnExitAllApplications(IGNITION_O
 
 This RPC has no additional parameter requirements
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
 	"jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnPutFile/index.md
+++ b/docs/BasicCommunication/OnPutFile/index.md
@@ -71,7 +71,9 @@ System Request file upload using Put File
 ![OnPutFile](./assets/OnPutFileSystemRequest.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnPutFile/index.md
+++ b/docs/BasicCommunication/OnPutFile/index.md
@@ -71,7 +71,7 @@ System Request file upload using Put File
 ![OnPutFile](./assets/OnPutFileSystemRequest.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnPutFile/index.md
+++ b/docs/BasicCommunication/OnPutFile/index.md
@@ -71,7 +71,7 @@ System Request file upload using Put File
 ![OnPutFile](./assets/OnPutFileSystemRequest.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnReady/index.md
+++ b/docs/BasicCommunication/OnReady/index.md
@@ -22,7 +22,7 @@ In order to communicate with SDL, the HMI must send this notification after the 
 
 This RPC has no additional parameter requirements
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnReady/index.md
+++ b/docs/BasicCommunication/OnReady/index.md
@@ -22,7 +22,7 @@ In order to communicate with SDL, the HMI must send this notification after the 
 
 This RPC has no additional parameter requirements
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnReady/index.md
+++ b/docs/BasicCommunication/OnReady/index.md
@@ -22,6 +22,12 @@ In order to communicate with SDL, the HMI must send this notification after the 
 
 This RPC has no additional parameter requirements
 
+### Sequence Diagrams
+|||
+OnReady WebSocket
+![OnReady](./assets/OnReady.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Notification
@@ -31,9 +37,3 @@ This RPC has no additional parameter requirements
   "method" : "BasicCommunication.OnReady"
 }
 ```
-
-### Sequence Diagrams
-|||
-OnReady WebSocket
-![OnReady](./assets/OnReady.png)
-|||

--- a/docs/BasicCommunication/OnReady/index.md
+++ b/docs/BasicCommunication/OnReady/index.md
@@ -22,7 +22,9 @@ In order to communicate with SDL, the HMI must send this notification after the 
 
 This RPC has no additional parameter requirements
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnResumeAudioSource/index.md
+++ b/docs/BasicCommunication/OnResumeAudioSource/index.md
@@ -55,7 +55,7 @@ Audio Source Resume one audio app one phone call app
 ![OnResumeAudioSource](./assets/OnResumeAudioSourceMultiple.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnResumeAudioSource/index.md
+++ b/docs/BasicCommunication/OnResumeAudioSource/index.md
@@ -55,7 +55,9 @@ Audio Source Resume one audio app one phone call app
 ![OnResumeAudioSource](./assets/OnResumeAudioSourceMultiple.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnResumeAudioSource/index.md
+++ b/docs/BasicCommunication/OnResumeAudioSource/index.md
@@ -55,7 +55,7 @@ Audio Source Resume one audio app one phone call app
 ![OnResumeAudioSource](./assets/OnResumeAudioSourceMultiple.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnSDLClose/index.md
+++ b/docs/BasicCommunication/OnSDLClose/index.md
@@ -42,7 +42,7 @@ OnSDLClose Master Reset
 ![OnSDLClose](./assets/OnSDLCloseReset.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnSDLClose/index.md
+++ b/docs/BasicCommunication/OnSDLClose/index.md
@@ -42,7 +42,9 @@ OnSDLClose Master Reset
 ![OnSDLClose](./assets/OnSDLCloseReset.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnSDLClose/index.md
+++ b/docs/BasicCommunication/OnSDLClose/index.md
@@ -42,7 +42,7 @@ OnSDLClose Master Reset
 ![OnSDLClose](./assets/OnSDLCloseReset.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnSDLPersistenceComplete/index.md
+++ b/docs/BasicCommunication/OnSDLPersistenceComplete/index.md
@@ -30,7 +30,9 @@ SDL Persists App Data after Suspend before Ignition Off
 ![OnSDLPersistenceComplete](./assets/OnSDLPersistenceComplete.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnSDLPersistenceComplete/index.md
+++ b/docs/BasicCommunication/OnSDLPersistenceComplete/index.md
@@ -30,7 +30,7 @@ SDL Persists App Data after Suspend before Ignition Off
 ![OnSDLPersistenceComplete](./assets/OnSDLPersistenceComplete.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnSDLPersistenceComplete/index.md
+++ b/docs/BasicCommunication/OnSDLPersistenceComplete/index.md
@@ -30,7 +30,7 @@ SDL Persists App Data after Suspend before Ignition Off
 ![OnSDLPersistenceComplete](./assets/OnSDLPersistenceComplete.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnServiceUpdate/index.md
+++ b/docs/BasicCommunication/OnServiceUpdate/index.md
@@ -45,7 +45,7 @@ OnServiceUpdate
 ![OnServiceUpdate](assets/OnServiceUpdate.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 
 ```json
 {

--- a/docs/BasicCommunication/OnServiceUpdate/index.md
+++ b/docs/BasicCommunication/OnServiceUpdate/index.md
@@ -45,7 +45,7 @@ OnServiceUpdate
 ![OnServiceUpdate](assets/OnServiceUpdate.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 
 ```json
 {

--- a/docs/BasicCommunication/OnServiceUpdate/index.md
+++ b/docs/BasicCommunication/OnServiceUpdate/index.md
@@ -45,7 +45,9 @@ OnServiceUpdate
 ![OnServiceUpdate](assets/OnServiceUpdate.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 
 ```json
 {

--- a/docs/BasicCommunication/OnStartDeviceDiscovery/index.md
+++ b/docs/BasicCommunication/OnStartDeviceDiscovery/index.md
@@ -23,7 +23,9 @@ This RPC tells SDL to initiate a new device search. The [OnUpdateDeviceList](../
 
 This RPC has no additional parameter requirements
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnStartDeviceDiscovery/index.md
+++ b/docs/BasicCommunication/OnStartDeviceDiscovery/index.md
@@ -23,7 +23,7 @@ This RPC tells SDL to initiate a new device search. The [OnUpdateDeviceList](../
 
 This RPC has no additional parameter requirements
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnStartDeviceDiscovery/index.md
+++ b/docs/BasicCommunication/OnStartDeviceDiscovery/index.md
@@ -23,6 +23,12 @@ This RPC tells SDL to initiate a new device search. The [OnUpdateDeviceList](../
 
 This RPC has no additional parameter requirements
 
+### Sequence Diagrams
+|||
+Starting Device Discovery
+![OnStartDeviceDiscovery](./assets/OnStartDeviceDiscovery.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Notification
@@ -32,9 +38,3 @@ This RPC has no additional parameter requirements
   "method" : "BasicCommunication.OnStartDeviceDiscovery"
 }
 ```
-
-### Sequence Diagrams
-|||
-Starting Device Discovery
-![OnStartDeviceDiscovery](./assets/OnStartDeviceDiscovery.png)
-|||

--- a/docs/BasicCommunication/OnStartDeviceDiscovery/index.md
+++ b/docs/BasicCommunication/OnStartDeviceDiscovery/index.md
@@ -23,7 +23,7 @@ This RPC tells SDL to initiate a new device search. The [OnUpdateDeviceList](../
 
 This RPC has no additional parameter requirements
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnSystemCapabilityUpdated/index.md
+++ b/docs/BasicCommunication/OnSystemCapabilityUpdated/index.md
@@ -31,7 +31,7 @@ OnSystemCapabilityUpdated(APP_SERVICES, REMOVED)
 ![OnSystemCapabilityUpdated_REMOVED](./assets/OnSystemCapabilityUpdated_REMOVED.png)
 |||
 
-### Example Notiifcation
+### JSON Example Notification
 
 ```json
 {

--- a/docs/BasicCommunication/OnSystemCapabilityUpdated/index.md
+++ b/docs/BasicCommunication/OnSystemCapabilityUpdated/index.md
@@ -31,7 +31,9 @@ OnSystemCapabilityUpdated(APP_SERVICES, REMOVED)
 ![OnSystemCapabilityUpdated_REMOVED](./assets/OnSystemCapabilityUpdated_REMOVED.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 
 ```json
 {

--- a/docs/BasicCommunication/OnSystemCapabilityUpdated/index.md
+++ b/docs/BasicCommunication/OnSystemCapabilityUpdated/index.md
@@ -31,7 +31,7 @@ OnSystemCapabilityUpdated(APP_SERVICES, REMOVED)
 ![OnSystemCapabilityUpdated_REMOVED](./assets/OnSystemCapabilityUpdated_REMOVED.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 
 ```json
 {

--- a/docs/BasicCommunication/OnSystemInfoChanged/index.md
+++ b/docs/BasicCommunication/OnSystemInfoChanged/index.md
@@ -17,7 +17,7 @@ Purpose
 |:---|:---|:--------|:---------|
 |language|[Common.Language](../../common/enums/#language)|true||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc": "2.0",

--- a/docs/BasicCommunication/OnSystemInfoChanged/index.md
+++ b/docs/BasicCommunication/OnSystemInfoChanged/index.md
@@ -17,7 +17,7 @@ Purpose
 |:---|:---|:--------|:---------|
 |language|[Common.Language](../../common/enums/#language)|true||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc": "2.0",

--- a/docs/BasicCommunication/OnSystemInfoChanged/index.md
+++ b/docs/BasicCommunication/OnSystemInfoChanged/index.md
@@ -17,7 +17,9 @@ Purpose
 |:---|:---|:--------|:---------|
 |language|[Common.Language](../../common/enums/#language)|true||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc": "2.0",

--- a/docs/BasicCommunication/OnSystemRequest/index.md
+++ b/docs/BasicCommunication/OnSystemRequest/index.md
@@ -63,7 +63,9 @@ BC.OnSystemRequest in "Proprietary" Policy Table Update Flow
 ![Proprietary PTU](./assets/OnSystemRequest_in_Proprietary_PTU_flow.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnSystemRequest/index.md
+++ b/docs/BasicCommunication/OnSystemRequest/index.md
@@ -63,7 +63,7 @@ BC.OnSystemRequest in "Proprietary" Policy Table Update Flow
 ![Proprietary PTU](./assets/OnSystemRequest_in_Proprietary_PTU_flow.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnSystemRequest/index.md
+++ b/docs/BasicCommunication/OnSystemRequest/index.md
@@ -63,7 +63,7 @@ BC.OnSystemRequest in "Proprietary" Policy Table Update Flow
 ![Proprietary PTU](./assets/OnSystemRequest_in_Proprietary_PTU_flow.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnSystemTimeReady/index.md
+++ b/docs/BasicCommunication/OnSystemTimeReady/index.md
@@ -27,7 +27,9 @@ OnSystemTimeReady
 ![OnSystemTimeReady](assets/OnSystemTimeReady_Ign_On.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 
 ```json
 {

--- a/docs/BasicCommunication/OnSystemTimeReady/index.md
+++ b/docs/BasicCommunication/OnSystemTimeReady/index.md
@@ -27,7 +27,7 @@ OnSystemTimeReady
 ![OnSystemTimeReady](assets/OnSystemTimeReady_Ign_On.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 
 ```json
 {

--- a/docs/BasicCommunication/OnSystemTimeReady/index.md
+++ b/docs/BasicCommunication/OnSystemTimeReady/index.md
@@ -27,7 +27,7 @@ OnSystemTimeReady
 ![OnSystemTimeReady](assets/OnSystemTimeReady_Ign_On.png)
 |||
 
-#### JSON Example Notification  
+### JSON Example Notification
 
 ```json
 {

--- a/docs/BasicCommunication/OnUpdateDeviceList/index.md
+++ b/docs/BasicCommunication/OnUpdateDeviceList/index.md
@@ -34,7 +34,7 @@ User Requests Device List Update
 ![OnUpdateDeviceList](./assets/OnUpdateDeviceList.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnUpdateDeviceList/index.md
+++ b/docs/BasicCommunication/OnUpdateDeviceList/index.md
@@ -34,7 +34,7 @@ User Requests Device List Update
 ![OnUpdateDeviceList](./assets/OnUpdateDeviceList.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/OnUpdateDeviceList/index.md
+++ b/docs/BasicCommunication/OnUpdateDeviceList/index.md
@@ -34,7 +34,9 @@ User Requests Device List Update
 ![OnUpdateDeviceList](./assets/OnUpdateDeviceList.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/BasicCommunication/PolicyUpdate/index.md
+++ b/docs/BasicCommunication/PolicyUpdate/index.md
@@ -80,7 +80,9 @@ BC.PolicyUpdate in "HTTP" Policy Table Update Flow
 ![HTTP PTU](./assets/PolicyUpdate_in_HTTP_PTU_flow.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -97,7 +99,7 @@ BC.PolicyUpdate in "HTTP" Policy Table Update Flow
 
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -112,7 +114,7 @@ BC.PolicyUpdate in "HTTP" Policy Table Update Flow
 
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/PolicyUpdate/index.md
+++ b/docs/BasicCommunication/PolicyUpdate/index.md
@@ -80,7 +80,7 @@ BC.PolicyUpdate in "HTTP" Policy Table Update Flow
 ![HTTP PTU](./assets/PolicyUpdate_in_HTTP_PTU_flow.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -97,7 +97,7 @@ BC.PolicyUpdate in "HTTP" Policy Table Update Flow
 
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -112,7 +112,7 @@ BC.PolicyUpdate in "HTTP" Policy Table Update Flow
 
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/PolicyUpdate/index.md
+++ b/docs/BasicCommunication/PolicyUpdate/index.md
@@ -80,7 +80,7 @@ BC.PolicyUpdate in "HTTP" Policy Table Update Flow
 ![HTTP PTU](./assets/PolicyUpdate_in_HTTP_PTU_flow.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -96,7 +96,8 @@ BC.PolicyUpdate in "HTTP" Policy Table Update Flow
 }
 
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -111,7 +112,7 @@ BC.PolicyUpdate in "HTTP" Policy Table Update Flow
 
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/SystemRequest/index.md
+++ b/docs/BasicCommunication/SystemRequest/index.md
@@ -51,7 +51,9 @@ If SDL sends a SystemRequest with `requestSubType` parameter to an older system,
 
 This RPC has no additional parameter requirements
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 ```json
 {
   "id" : 59,
@@ -66,7 +68,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Response
+#### Example Response
 ```json
 {
   "id" : 59,
@@ -79,7 +81,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Error
+#### Example Error
 ```json
 {
   "id" : 59,

--- a/docs/BasicCommunication/SystemRequest/index.md
+++ b/docs/BasicCommunication/SystemRequest/index.md
@@ -51,6 +51,12 @@ If SDL sends a SystemRequest with `requestSubType` parameter to an older system,
 
 This RPC has no additional parameter requirements
 
+### Sequence Diagrams
+|||
+System Request Workflow
+![System Request](./assets/SystemRequestWorkflow.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Request
@@ -97,9 +103,3 @@ This RPC has no additional parameter requirements
   }
 }
 ```
-
-### Sequence Diagrams
-|||
-System Request Workflow
-![System Request](./assets/SystemRequestWorkflow.png)
-|||

--- a/docs/BasicCommunication/SystemRequest/index.md
+++ b/docs/BasicCommunication/SystemRequest/index.md
@@ -51,7 +51,7 @@ If SDL sends a SystemRequest with `requestSubType` parameter to an older system,
 
 This RPC has no additional parameter requirements
 
-### JSON Example Request
+### Example Request
 ```json
 {
   "id" : 59,
@@ -66,7 +66,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### JSON Example Response
+### Example Response
 ```json
 {
   "id" : 59,
@@ -79,7 +79,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### JSON Example Error
+### Example Error
 ```json
 {
   "id" : 59,

--- a/docs/BasicCommunication/SystemRequest/index.md
+++ b/docs/BasicCommunication/SystemRequest/index.md
@@ -51,7 +51,7 @@ If SDL sends a SystemRequest with `requestSubType` parameter to an older system,
 
 This RPC has no additional parameter requirements
 
-### Example Request
+### JSON Example Request
 ```json
 {
   "id" : 59,
@@ -66,7 +66,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Response
+### JSON Example Response
 ```json
 {
   "id" : 59,
@@ -79,7 +79,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Error
+### JSON Example Error
 ```json
 {
   "id" : 59,

--- a/docs/BasicCommunication/UpdateAppList/index.md
+++ b/docs/BasicCommunication/UpdateAppList/index.md
@@ -56,7 +56,9 @@ User Requests Update App List
 ![UpdateAppList](./assets/UpdateAppListUser.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -102,7 +104,7 @@ User Requests Update App List
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -116,7 +118,7 @@ User Requests Update App List
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/UpdateAppList/index.md
+++ b/docs/BasicCommunication/UpdateAppList/index.md
@@ -56,7 +56,7 @@ User Requests Update App List
 ![UpdateAppList](./assets/UpdateAppListUser.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -102,7 +102,7 @@ User Requests Update App List
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -116,7 +116,7 @@ User Requests Update App List
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/UpdateAppList/index.md
+++ b/docs/BasicCommunication/UpdateAppList/index.md
@@ -56,7 +56,7 @@ User Requests Update App List
 ![UpdateAppList](./assets/UpdateAppListUser.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -101,7 +101,8 @@ User Requests Update App List
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -115,7 +116,7 @@ User Requests Update App List
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/UpdateDeviceList/index.md
+++ b/docs/BasicCommunication/UpdateDeviceList/index.md
@@ -61,7 +61,7 @@ The SDL's default Transport Manager (TM) and Transport Adapters (TA) behave in t
 
 This RPC has no additional parameter requirements
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -86,7 +86,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -99,7 +99,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/UpdateDeviceList/index.md
+++ b/docs/BasicCommunication/UpdateDeviceList/index.md
@@ -61,6 +61,21 @@ The SDL's default Transport Manager (TM) and Transport Adapters (TA) behave in t
 
 This RPC has no additional parameter requirements
 
+### Sequence Diagrams
+
+|||
+UpdateDeviceList after SDL discovers device over BT or USB
+![Update Device List BT USB](./assets/UpdateDeviceListBTUSB.png)
+|||
+|||
+UpdateDeviceList iOS
+![Update Device List iOS](./assets/UpdateDeviceListiOS.png)
+|||
+|||
+UpdateDeviceList USB AOA
+![Update Device List AOA](./assets/UpdateDeviceListAOA.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Request
@@ -116,18 +131,3 @@ This RPC has no additional parameter requirements
   }
 }
 ```
-
-### Sequence Diagrams
-
-|||
-UpdateDeviceList after SDL discovers device over BT or USB
-![Update Device List BT USB](./assets/UpdateDeviceListBTUSB.png)
-|||
-|||
-UpdateDeviceList iOS
-![Update Device List iOS](./assets/UpdateDeviceListiOS.png)
-|||
-|||
-UpdateDeviceList USB AOA
-![Update Device List AOA](./assets/UpdateDeviceListAOA.png)
-|||

--- a/docs/BasicCommunication/UpdateDeviceList/index.md
+++ b/docs/BasicCommunication/UpdateDeviceList/index.md
@@ -61,7 +61,7 @@ The SDL's default Transport Manager (TM) and Transport Adapters (TA) behave in t
 
 This RPC has no additional parameter requirements
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -86,7 +86,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -99,7 +99,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/BasicCommunication/UpdateDeviceList/index.md
+++ b/docs/BasicCommunication/UpdateDeviceList/index.md
@@ -61,7 +61,9 @@ The SDL's default Transport Manager (TM) and Transport Adapters (TA) behave in t
 
 This RPC has no additional parameter requirements
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -86,7 +88,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -99,7 +101,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Buttons/ButtonPress/index.md
+++ b/docs/Buttons/ButtonPress/index.md
@@ -50,7 +50,7 @@ ButtonPress
 ![ButtonPress](assets/ButtonPress.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -65,7 +65,7 @@ ButtonPress
     }
 }
 ```
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -78,7 +78,7 @@ ButtonPress
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Buttons/ButtonPress/index.md
+++ b/docs/Buttons/ButtonPress/index.md
@@ -50,7 +50,7 @@ ButtonPress
 ![ButtonPress](assets/ButtonPress.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -65,7 +65,7 @@ ButtonPress
     }
 }
 ```
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -78,7 +78,7 @@ ButtonPress
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Buttons/ButtonPress/index.md
+++ b/docs/Buttons/ButtonPress/index.md
@@ -50,7 +50,9 @@ ButtonPress
 ![ButtonPress](assets/ButtonPress.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -65,7 +67,7 @@ ButtonPress
     }
 }
 ```
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -78,7 +80,7 @@ ButtonPress
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Buttons/GetCapabilities/index.md
+++ b/docs/Buttons/GetCapabilities/index.md
@@ -30,7 +30,7 @@ GetCapabilities on system startup
 ![GetCapabilities](./assets/GetCapabilities.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -39,7 +39,8 @@ GetCapabilities on system startup
   "method" : "Buttons.GetCapabilities"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -90,7 +91,7 @@ GetCapabilities on system startup
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Buttons/GetCapabilities/index.md
+++ b/docs/Buttons/GetCapabilities/index.md
@@ -30,7 +30,7 @@ GetCapabilities on system startup
 ![GetCapabilities](./assets/GetCapabilities.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -40,7 +40,7 @@ GetCapabilities on system startup
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -91,7 +91,7 @@ GetCapabilities on system startup
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Buttons/GetCapabilities/index.md
+++ b/docs/Buttons/GetCapabilities/index.md
@@ -30,7 +30,9 @@ GetCapabilities on system startup
 ![GetCapabilities](./assets/GetCapabilities.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -40,7 +42,7 @@ GetCapabilities on system startup
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -91,7 +93,7 @@ GetCapabilities on system startup
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Buttons/OnButtonEvent/index.md
+++ b/docs/Buttons/OnButtonEvent/index.md
@@ -30,7 +30,7 @@ OnButtonEvent hardware button pressed and released
 ![OnButtonEvent](./assets/OnButtonEventHardKeyPressRelease.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Buttons/OnButtonEvent/index.md
+++ b/docs/Buttons/OnButtonEvent/index.md
@@ -30,7 +30,9 @@ OnButtonEvent hardware button pressed and released
 ![OnButtonEvent](./assets/OnButtonEventHardKeyPressRelease.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Buttons/OnButtonEvent/index.md
+++ b/docs/Buttons/OnButtonEvent/index.md
@@ -30,7 +30,7 @@ OnButtonEvent hardware button pressed and released
 ![OnButtonEvent](./assets/OnButtonEventHardKeyPressRelease.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Buttons/OnButtonPress/index.md
+++ b/docs/Buttons/OnButtonPress/index.md
@@ -48,7 +48,7 @@ OnButtonPress for hard button that only supports short press
 ![OnButtonPress](./assets/OnButtonPressHardKeyShortOnly.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Buttons/OnButtonPress/index.md
+++ b/docs/Buttons/OnButtonPress/index.md
@@ -48,7 +48,7 @@ OnButtonPress for hard button that only supports short press
 ![OnButtonPress](./assets/OnButtonPressHardKeyShortOnly.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Buttons/OnButtonPress/index.md
+++ b/docs/Buttons/OnButtonPress/index.md
@@ -48,7 +48,9 @@ OnButtonPress for hard button that only supports short press
 ![OnButtonPress](./assets/OnButtonPressHardKeyShortOnly.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Buttons/OnButtonSubscription/index.md
+++ b/docs/Buttons/OnButtonSubscription/index.md
@@ -25,7 +25,9 @@ OnButtonSubscription
 ![OnButtonSubscription](./assets/OnButtonSubscription.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Buttons/OnButtonSubscription/index.md
+++ b/docs/Buttons/OnButtonSubscription/index.md
@@ -25,7 +25,7 @@ OnButtonSubscription
 ![OnButtonSubscription](./assets/OnButtonSubscription.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Buttons/OnButtonSubscription/index.md
+++ b/docs/Buttons/OnButtonSubscription/index.md
@@ -25,7 +25,7 @@ OnButtonSubscription
 ![OnButtonSubscription](./assets/OnButtonSubscription.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Navigation/AlertManeuver/index.md
+++ b/docs/Navigation/AlertManeuver/index.md
@@ -70,7 +70,7 @@ AlertManeuver Rejected
 ![AlertManeuver](./assets/AlertManeuverRejected.jpg)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -97,7 +97,7 @@ AlertManeuver Rejected
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -111,7 +111,7 @@ AlertManeuver Rejected
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Navigation/AlertManeuver/index.md
+++ b/docs/Navigation/AlertManeuver/index.md
@@ -70,7 +70,7 @@ AlertManeuver Rejected
 ![AlertManeuver](./assets/AlertManeuverRejected.jpg)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -97,7 +97,7 @@ AlertManeuver Rejected
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -111,7 +111,7 @@ AlertManeuver Rejected
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/AlertManeuver/index.md
+++ b/docs/Navigation/AlertManeuver/index.md
@@ -70,7 +70,9 @@ AlertManeuver Rejected
 ![AlertManeuver](./assets/AlertManeuverRejected.jpg)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -97,7 +99,7 @@ AlertManeuver Rejected
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -111,7 +113,7 @@ AlertManeuver Rejected
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/GetWayPoints/index.md
+++ b/docs/Navigation/GetWayPoints/index.md
@@ -57,7 +57,9 @@ GetWayPoints
 ![GetWayPoints](./assets/GetWayPoints.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -72,7 +74,7 @@ GetWayPoints
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -93,7 +95,7 @@ GetWayPoints
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/GetWayPoints/index.md
+++ b/docs/Navigation/GetWayPoints/index.md
@@ -57,9 +57,7 @@ GetWayPoints
 ![GetWayPoints](./assets/GetWayPoints.png)
 |||
 
-### JSON Messages Examples
-
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -74,7 +72,7 @@ GetWayPoints
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -95,7 +93,7 @@ GetWayPoints
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/GetWayPoints/index.md
+++ b/docs/Navigation/GetWayPoints/index.md
@@ -57,7 +57,7 @@ GetWayPoints
 ![GetWayPoints](./assets/GetWayPoints.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -72,7 +72,7 @@ GetWayPoints
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -93,7 +93,7 @@ GetWayPoints
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Navigation/IsReady/index.md
+++ b/docs/Navigation/IsReady/index.md
@@ -44,7 +44,7 @@ IsReady
 ![IsReady](./assets/IsReady.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -53,7 +53,8 @@ IsReady
   "method" : "Navigation.IsReady"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -68,7 +69,7 @@ IsReady
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/IsReady/index.md
+++ b/docs/Navigation/IsReady/index.md
@@ -44,7 +44,9 @@ IsReady
 ![IsReady](./assets/IsReady.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -54,7 +56,7 @@ IsReady
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -69,7 +71,7 @@ IsReady
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/IsReady/index.md
+++ b/docs/Navigation/IsReady/index.md
@@ -44,7 +44,7 @@ IsReady
 ![IsReady](./assets/IsReady.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -54,7 +54,7 @@ IsReady
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -69,7 +69,7 @@ IsReady
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Navigation/OnAudioDataStreaming/index.md
+++ b/docs/Navigation/OnAudioDataStreaming/index.md
@@ -28,7 +28,7 @@ OnAudioDataStreaming App to HMI
 ![OnAudioDataStreaming](./assets/OnAudioDataStreamingAppHMI.jpg)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Navigation/OnAudioDataStreaming/index.md
+++ b/docs/Navigation/OnAudioDataStreaming/index.md
@@ -28,7 +28,9 @@ OnAudioDataStreaming App to HMI
 ![OnAudioDataStreaming](./assets/OnAudioDataStreamingAppHMI.jpg)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Navigation/OnAudioDataStreaming/index.md
+++ b/docs/Navigation/OnAudioDataStreaming/index.md
@@ -28,7 +28,7 @@ OnAudioDataStreaming App to HMI
 ![OnAudioDataStreaming](./assets/OnAudioDataStreamingAppHMI.jpg)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Navigation/OnTBTClientState/index.md
+++ b/docs/Navigation/OnTBTClientState/index.md
@@ -23,7 +23,7 @@ OnTBTClientState
 ![OnTBTClientState](./assets/OnTBTClientState.jpg)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Navigation/OnTBTClientState/index.md
+++ b/docs/Navigation/OnTBTClientState/index.md
@@ -23,7 +23,7 @@ OnTBTClientState
 ![OnTBTClientState](./assets/OnTBTClientState.jpg)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Navigation/OnTBTClientState/index.md
+++ b/docs/Navigation/OnTBTClientState/index.md
@@ -23,7 +23,9 @@ OnTBTClientState
 ![OnTBTClientState](./assets/OnTBTClientState.jpg)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Navigation/OnVideoDataStreaming/index.md
+++ b/docs/Navigation/OnVideoDataStreaming/index.md
@@ -23,7 +23,7 @@ OnVideoDataStreaming
 ![OnVideoDataStreaming](./assets/OnVideoDataStreaming.jpg)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Navigation/OnVideoDataStreaming/index.md
+++ b/docs/Navigation/OnVideoDataStreaming/index.md
@@ -23,7 +23,9 @@ OnVideoDataStreaming
 ![OnVideoDataStreaming](./assets/OnVideoDataStreaming.jpg)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Navigation/OnVideoDataStreaming/index.md
+++ b/docs/Navigation/OnVideoDataStreaming/index.md
@@ -23,7 +23,7 @@ OnVideoDataStreaming
 ![OnVideoDataStreaming](./assets/OnVideoDataStreaming.jpg)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/Navigation/OnWayPointChange/index.md
+++ b/docs/Navigation/OnWayPointChange/index.md
@@ -27,7 +27,7 @@ OnWayPointChange
 ![OnWayPointChange](./assets/OnWayPointChange.png)
 |||
 
-### Example Notification
+### JSON Example Notification
 
 ```json
 {

--- a/docs/Navigation/OnWayPointChange/index.md
+++ b/docs/Navigation/OnWayPointChange/index.md
@@ -27,7 +27,9 @@ OnWayPointChange
 ![OnWayPointChange](./assets/OnWayPointChange.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 
 ```json
 {

--- a/docs/Navigation/OnWayPointChange/index.md
+++ b/docs/Navigation/OnWayPointChange/index.md
@@ -27,7 +27,7 @@ OnWayPointChange
 ![OnWayPointChange](./assets/OnWayPointChange.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 
 ```json
 {

--- a/docs/Navigation/SendLocation/index.md
+++ b/docs/Navigation/SendLocation/index.md
@@ -59,7 +59,9 @@ SendLocation General behavior
 ![SendLocation](./assets/SendLocation_general.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -80,7 +82,7 @@ SendLocation General behavior
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -94,7 +96,7 @@ SendLocation General behavior
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/SendLocation/index.md
+++ b/docs/Navigation/SendLocation/index.md
@@ -42,7 +42,7 @@ Purpose
 
 This RPC has no additional parameter requirements
 
-### Sequence Diagram
+### Sequence Diagrams
 |||
 SendLocation Success
 ![SendLocation](./assets/SendLocationSuccess.jpg)
@@ -59,7 +59,7 @@ SendLocation General behavior
 ![SendLocation](./assets/SendLocation_general.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -80,7 +80,7 @@ SendLocation General behavior
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -94,7 +94,7 @@ SendLocation General behavior
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Navigation/SendLocation/index.md
+++ b/docs/Navigation/SendLocation/index.md
@@ -59,7 +59,7 @@ SendLocation General behavior
 ![SendLocation](./assets/SendLocation_general.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -79,7 +79,8 @@ SendLocation General behavior
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -93,7 +94,7 @@ SendLocation General behavior
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/SetVideoConfig/index.md
+++ b/docs/Navigation/SetVideoConfig/index.md
@@ -52,7 +52,7 @@ SetVideoConfig error flow
 ![SetVideoConfig](./assets/SetVideoConfigErrorFlow.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -73,7 +73,7 @@ SetVideoConfig error flow
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -87,7 +87,7 @@ SetVideoConfig error flow
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/SetVideoConfig/index.md
+++ b/docs/Navigation/SetVideoConfig/index.md
@@ -52,7 +52,7 @@ SetVideoConfig error flow
 ![SetVideoConfig](./assets/SetVideoConfigErrorFlow.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -73,7 +73,7 @@ SetVideoConfig error flow
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -87,7 +87,7 @@ SetVideoConfig error flow
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Navigation/SetVideoConfig/index.md
+++ b/docs/Navigation/SetVideoConfig/index.md
@@ -52,7 +52,9 @@ SetVideoConfig error flow
 ![SetVideoConfig](./assets/SetVideoConfigErrorFlow.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -73,7 +75,7 @@ SetVideoConfig error flow
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -87,7 +89,7 @@ SetVideoConfig error flow
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/ShowConstantTBT/index.md
+++ b/docs/Navigation/ShowConstantTBT/index.md
@@ -36,7 +36,9 @@ ShowConstantTBT
 ![ShowConstantTBT](./assets/ShowConstantTBT.jpg)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -79,7 +81,7 @@ ShowConstantTBT
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -93,7 +95,7 @@ ShowConstantTBT
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/ShowConstantTBT/index.md
+++ b/docs/Navigation/ShowConstantTBT/index.md
@@ -36,7 +36,7 @@ ShowConstantTBT
 ![ShowConstantTBT](./assets/ShowConstantTBT.jpg)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -79,7 +79,7 @@ ShowConstantTBT
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -93,7 +93,7 @@ ShowConstantTBT
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Navigation/ShowConstantTBT/index.md
+++ b/docs/Navigation/ShowConstantTBT/index.md
@@ -36,7 +36,7 @@ ShowConstantTBT
 ![ShowConstantTBT](./assets/ShowConstantTBT.jpg)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -78,7 +78,8 @@ ShowConstantTBT
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -92,7 +93,7 @@ ShowConstantTBT
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/StartAudioStream/index.md
+++ b/docs/Navigation/StartAudioStream/index.md
@@ -30,7 +30,7 @@ StartAudioStream
 ![StartAudioStream](./assets/StartAudioStream.jpg)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -43,7 +43,8 @@ StartAudioStream
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -57,7 +58,7 @@ StartAudioStream
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/StartAudioStream/index.md
+++ b/docs/Navigation/StartAudioStream/index.md
@@ -30,7 +30,9 @@ StartAudioStream
 ![StartAudioStream](./assets/StartAudioStream.jpg)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -44,7 +46,7 @@ StartAudioStream
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -58,7 +60,7 @@ StartAudioStream
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/StartAudioStream/index.md
+++ b/docs/Navigation/StartAudioStream/index.md
@@ -30,7 +30,7 @@ StartAudioStream
 ![StartAudioStream](./assets/StartAudioStream.jpg)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -44,7 +44,7 @@ StartAudioStream
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -58,7 +58,7 @@ StartAudioStream
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Navigation/StartStream/index.md
+++ b/docs/Navigation/StartStream/index.md
@@ -30,7 +30,7 @@ StartStream
 ![StartStream](./assets/StartStream.jpg)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -44,7 +44,7 @@ StartStream
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -58,7 +58,7 @@ StartStream
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Navigation/StartStream/index.md
+++ b/docs/Navigation/StartStream/index.md
@@ -30,7 +30,7 @@ StartStream
 ![StartStream](./assets/StartStream.jpg)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -43,7 +43,8 @@ StartStream
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -57,7 +58,7 @@ StartStream
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/StartStream/index.md
+++ b/docs/Navigation/StartStream/index.md
@@ -30,7 +30,9 @@ StartStream
 ![StartStream](./assets/StartStream.jpg)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -44,7 +46,7 @@ StartStream
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -58,7 +60,7 @@ StartStream
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/StopAudioStream/index.md
+++ b/docs/Navigation/StopAudioStream/index.md
@@ -29,7 +29,7 @@ StopAudioStream
 ![StopAudioStream](./assets/StopAudioStream.jpg)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -42,7 +42,7 @@ StopAudioStream
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -56,7 +56,7 @@ StopAudioStream
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Navigation/StopAudioStream/index.md
+++ b/docs/Navigation/StopAudioStream/index.md
@@ -29,7 +29,7 @@ StopAudioStream
 ![StopAudioStream](./assets/StopAudioStream.jpg)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -41,7 +41,8 @@ StopAudioStream
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -55,7 +56,7 @@ StopAudioStream
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/StopAudioStream/index.md
+++ b/docs/Navigation/StopAudioStream/index.md
@@ -29,7 +29,9 @@ StopAudioStream
 ![StopAudioStream](./assets/StopAudioStream.jpg)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -42,7 +44,7 @@ StopAudioStream
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -56,7 +58,7 @@ StopAudioStream
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/StopStream/index.md
+++ b/docs/Navigation/StopStream/index.md
@@ -12,6 +12,8 @@ Purpose
 The app must stop video streaming after receiving onHMIStatus with videoStreamingState=NOT_STREAMBLE. 
 If the app does not stop streaming after certain amount of time, SDL sends a StopService Control Frame to the app in protocol layer.
 
+### Request
+
 #### Parameters
 
 |Name|Type|Mandatory|Additional|
@@ -30,7 +32,7 @@ StopStream
 ![StopStream](./assets/StopStream.jpg)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -42,7 +44,8 @@ StopStream
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -56,7 +59,7 @@ StopStream
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/StopStream/index.md
+++ b/docs/Navigation/StopStream/index.md
@@ -32,7 +32,9 @@ StopStream
 ![StopStream](./assets/StopStream.jpg)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -45,7 +47,7 @@ StopStream
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -59,7 +61,7 @@ StopStream
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/StopStream/index.md
+++ b/docs/Navigation/StopStream/index.md
@@ -32,7 +32,7 @@ StopStream
 ![StopStream](./assets/StopStream.jpg)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -45,7 +45,7 @@ StopStream
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -59,7 +59,7 @@ StopStream
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Navigation/SubscribeWayPoints/index.md
+++ b/docs/Navigation/SubscribeWayPoints/index.md
@@ -31,7 +31,7 @@ SubscribeWayPoints
 ![SubscribeWayPoints](./assets/SubscribeWayPoints.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -42,7 +42,7 @@ SubscribeWayPoints
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -56,7 +56,7 @@ SubscribeWayPoints
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Navigation/SubscribeWayPoints/index.md
+++ b/docs/Navigation/SubscribeWayPoints/index.md
@@ -31,7 +31,7 @@ SubscribeWayPoints
 ![SubscribeWayPoints](./assets/SubscribeWayPoints.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -42,7 +42,7 @@ SubscribeWayPoints
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -56,7 +56,7 @@ SubscribeWayPoints
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/SubscribeWayPoints/index.md
+++ b/docs/Navigation/SubscribeWayPoints/index.md
@@ -31,7 +31,9 @@ SubscribeWayPoints
 ![SubscribeWayPoints](./assets/SubscribeWayPoints.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -42,7 +44,7 @@ SubscribeWayPoints
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -56,7 +58,7 @@ SubscribeWayPoints
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/UnsubscribeWayPoints/index.md
+++ b/docs/Navigation/UnsubscribeWayPoints/index.md
@@ -31,7 +31,7 @@ UnsubscribeWayPoints
 ![UnsubscribeWayPoints](./assets/UnsubscribeWayPoints.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -42,7 +42,7 @@ UnsubscribeWayPoints
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -56,7 +56,7 @@ UnsubscribeWayPoints
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/UnsubscribeWayPoints/index.md
+++ b/docs/Navigation/UnsubscribeWayPoints/index.md
@@ -31,7 +31,9 @@ UnsubscribeWayPoints
 ![UnsubscribeWayPoints](./assets/UnsubscribeWayPoints.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -42,7 +44,7 @@ UnsubscribeWayPoints
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -56,7 +58,7 @@ UnsubscribeWayPoints
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/UnsubscribeWayPoints/index.md
+++ b/docs/Navigation/UnsubscribeWayPoints/index.md
@@ -31,7 +31,7 @@ UnsubscribeWayPoints
 ![UnsubscribeWayPoints](./assets/UnsubscribeWayPoints.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -42,7 +42,7 @@ UnsubscribeWayPoints
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -56,7 +56,7 @@ UnsubscribeWayPoints
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/Navigation/UpdateTurnList/index.md
+++ b/docs/Navigation/UpdateTurnList/index.md
@@ -31,7 +31,9 @@ UpdateTurnList
 ![UpdateTurnList](./assets/UpdateTurnList.jpg)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -99,7 +101,7 @@ UpdateTurnList
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -113,7 +115,7 @@ UpdateTurnList
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/Navigation/UpdateTurnList/index.md
+++ b/docs/Navigation/UpdateTurnList/index.md
@@ -31,7 +31,7 @@ UpdateTurnList
 ![UpdateTurnList](./assets/UpdateTurnList.jpg)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -98,7 +98,8 @@ UpdateTurnList
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -112,7 +113,7 @@ UpdateTurnList
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/Navigation/UpdateTurnList/index.md
+++ b/docs/Navigation/UpdateTurnList/index.md
@@ -31,7 +31,7 @@ UpdateTurnList
 ![UpdateTurnList](./assets/UpdateTurnList.jpg)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -99,7 +99,7 @@ UpdateTurnList
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -113,7 +113,7 @@ UpdateTurnList
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/RC/GetCapabilities/index.md
+++ b/docs/RC/GetCapabilities/index.md
@@ -42,7 +42,7 @@ GetCapabilities
 ![GetCapabilities](assets/IsReady_GetCapabilities.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -52,7 +52,7 @@ GetCapabilities
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -218,7 +218,7 @@ GetCapabilities
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/RC/GetCapabilities/index.md
+++ b/docs/RC/GetCapabilities/index.md
@@ -42,7 +42,9 @@ GetCapabilities
 ![GetCapabilities](assets/IsReady_GetCapabilities.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -52,7 +54,7 @@ GetCapabilities
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -218,7 +220,7 @@ GetCapabilities
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/RC/GetCapabilities/index.md
+++ b/docs/RC/GetCapabilities/index.md
@@ -42,7 +42,7 @@ GetCapabilities
 ![GetCapabilities](assets/IsReady_GetCapabilities.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -52,7 +52,7 @@ GetCapabilities
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -217,7 +217,8 @@ GetCapabilities
   }
 }
 ```
-### Example Error
+
+### JSON Example Error
 
 ```json
 {

--- a/docs/RC/GetInteriorVehicleData/index.md
+++ b/docs/RC/GetInteriorVehicleData/index.md
@@ -19,7 +19,7 @@ Otherwise, SDL responds to the request with the cached data without forwarding i
 
 The HMI should return interior vehicle data that corresponds to the requested module (`moduleId` + `moduleType`).
 
-### Request  
+### Request
 
 GetInteriorVehicleData is a request originated by a Remote Control Mobile Application. 
 If the optional `moduleId` is not provided in a GetInteriorVehicleData_request from a Remote Control Mobile Application, and if there is at least one module (published by capabilities) of the same moduleType, SDL core will use the default `moduleId` (the moduleId of first module provided in RC capabilities for requested `moduleType`) when processing the request.
@@ -53,7 +53,7 @@ GetInteriorVehicleData
 ![GetInteriorVehicleData](assets/GetInteriorVehicleData.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -67,7 +67,7 @@ GetInteriorVehicleData
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -103,7 +103,7 @@ GetInteriorVehicleData
 
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/RC/GetInteriorVehicleData/index.md
+++ b/docs/RC/GetInteriorVehicleData/index.md
@@ -53,7 +53,7 @@ GetInteriorVehicleData
 ![GetInteriorVehicleData](assets/GetInteriorVehicleData.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -67,7 +67,7 @@ GetInteriorVehicleData
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -103,7 +103,7 @@ GetInteriorVehicleData
 
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/RC/GetInteriorVehicleData/index.md
+++ b/docs/RC/GetInteriorVehicleData/index.md
@@ -53,7 +53,9 @@ GetInteriorVehicleData
 ![GetInteriorVehicleData](assets/GetInteriorVehicleData.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -67,7 +69,7 @@ GetInteriorVehicleData
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -103,7 +105,7 @@ GetInteriorVehicleData
 
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/RC/GetInteriorVehicleDataConsent/index.md
+++ b/docs/RC/GetInteriorVehicleDataConsent/index.md
@@ -43,7 +43,7 @@ GetInteriorVehicleDataConsent
 ![GetInteriorVehicleDataConsent](assets/GetInteriorVehicleDataConsent.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -57,7 +57,7 @@ GetInteriorVehicleDataConsent
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -71,7 +71,7 @@ GetInteriorVehicleDataConsent
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/RC/GetInteriorVehicleDataConsent/index.md
+++ b/docs/RC/GetInteriorVehicleDataConsent/index.md
@@ -43,7 +43,9 @@ GetInteriorVehicleDataConsent
 ![GetInteriorVehicleDataConsent](assets/GetInteriorVehicleDataConsent.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -57,7 +59,7 @@ GetInteriorVehicleDataConsent
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -71,7 +73,7 @@ GetInteriorVehicleDataConsent
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/RC/GetInteriorVehicleDataConsent/index.md
+++ b/docs/RC/GetInteriorVehicleDataConsent/index.md
@@ -43,7 +43,7 @@ GetInteriorVehicleDataConsent
 ![GetInteriorVehicleDataConsent](assets/GetInteriorVehicleDataConsent.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -57,7 +57,7 @@ GetInteriorVehicleDataConsent
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -71,7 +71,7 @@ GetInteriorVehicleDataConsent
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/RC/IsReady/index.md
+++ b/docs/RC/IsReady/index.md
@@ -46,7 +46,7 @@ IsReady
 ![IsReady](./assets/IsReady_GetCapabilities.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -56,7 +56,7 @@ IsReady
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -71,7 +71,7 @@ IsReady
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/RC/IsReady/index.md
+++ b/docs/RC/IsReady/index.md
@@ -46,7 +46,7 @@ IsReady
 ![IsReady](./assets/IsReady_GetCapabilities.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -56,7 +56,7 @@ IsReady
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -71,7 +71,7 @@ IsReady
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/RC/IsReady/index.md
+++ b/docs/RC/IsReady/index.md
@@ -46,7 +46,9 @@ IsReady
 ![IsReady](./assets/IsReady_GetCapabilities.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -56,7 +58,7 @@ IsReady
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -71,7 +73,7 @@ IsReady
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/RC/OnInteriorVehicleData/index.md
+++ b/docs/RC/OnInteriorVehicleData/index.md
@@ -37,7 +37,9 @@ OnInteriorVehicledata
 ![OnInteriorVehicleData](assets/OnInteriorVehicleData.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
     "jsonrpc": "2.0",

--- a/docs/RC/OnInteriorVehicleData/index.md
+++ b/docs/RC/OnInteriorVehicleData/index.md
@@ -37,7 +37,7 @@ OnInteriorVehicledata
 ![OnInteriorVehicleData](assets/OnInteriorVehicleData.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
     "jsonrpc": "2.0",

--- a/docs/RC/OnInteriorVehicleData/index.md
+++ b/docs/RC/OnInteriorVehicleData/index.md
@@ -37,7 +37,7 @@ OnInteriorVehicledata
 ![OnInteriorVehicleData](assets/OnInteriorVehicleData.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
     "jsonrpc": "2.0",

--- a/docs/RC/OnRCStatus/index.md
+++ b/docs/RC/OnRCStatus/index.md
@@ -28,7 +28,7 @@ SDL must always include `moduleId` for each and every `ModuleData` in `allocated
 |allocatedModules|[Common.ModuleData](../../common/structs/#moduledata)|true|array: true<br>minsize: 0<br>maxsize: 100|Contains a list (zero or more) of module types that are allocated to the application|
 |freeModules|[Common.ModuleData](../../common/structs/#moduledata)|true|array: true<br>minsize: 0<br>maxsize: 100|Contains a list (zero or more) of module types that are free to access for the application|
 
-#### JSON Example Notification
+### JSON Example Notification
 
 ```json
 {

--- a/docs/RC/OnRCStatus/index.md
+++ b/docs/RC/OnRCStatus/index.md
@@ -28,6 +28,13 @@ SDL must always include `moduleId` for each and every `ModuleData` in `allocated
 |allocatedModules|[Common.ModuleData](../../common/structs/#moduledata)|true|array: true<br>minsize: 0<br>maxsize: 100|Contains a list (zero or more) of module types that are allocated to the application|
 |freeModules|[Common.ModuleData](../../common/structs/#moduledata)|true|array: true<br>minsize: 0<br>maxsize: 100|Contains a list (zero or more) of module types that are free to access for the application|
 
+### Sequence Diagrams
+
+|||
+OnRCStatus
+![OnRCStatus](assets/OnRCStatus.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Notification
@@ -60,10 +67,3 @@ SDL must always include `moduleId` for each and every `ModuleData` in `allocated
 	}
 }
 ```
-
-### Sequence Diagrams
-
-|||
-OnRCStatus
-![OnRCStatus](assets/OnRCStatus.png)
-|||

--- a/docs/RC/OnRCStatus/index.md
+++ b/docs/RC/OnRCStatus/index.md
@@ -28,7 +28,9 @@ SDL must always include `moduleId` for each and every `ModuleData` in `allocated
 |allocatedModules|[Common.ModuleData](../../common/structs/#moduledata)|true|array: true<br>minsize: 0<br>maxsize: 100|Contains a list (zero or more) of module types that are allocated to the application|
 |freeModules|[Common.ModuleData](../../common/structs/#moduledata)|true|array: true<br>minsize: 0<br>maxsize: 100|Contains a list (zero or more) of module types that are free to access for the application|
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 
 ```json
 {

--- a/docs/RC/OnRCStatus/index.md
+++ b/docs/RC/OnRCStatus/index.md
@@ -28,7 +28,7 @@ SDL must always include `moduleId` for each and every `ModuleData` in `allocated
 |allocatedModules|[Common.ModuleData](../../common/structs/#moduledata)|true|array: true<br>minsize: 0<br>maxsize: 100|Contains a list (zero or more) of module types that are allocated to the application|
 |freeModules|[Common.ModuleData](../../common/structs/#moduledata)|true|array: true<br>minsize: 0<br>maxsize: 100|Contains a list (zero or more) of module types that are free to access for the application|
 
-### JSON Example Notification
+### Example Notification
 
 ```json
 {

--- a/docs/RC/OnRemoteControlSettings/index.md
+++ b/docs/RC/OnRemoteControlSettings/index.md
@@ -34,7 +34,7 @@ OnRemoteControlSettings disabling RC
 ![OnRemoteControlSettings disabling RC](./assets/OnRemoteControlSettings_disablingRC.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 
 ```json
 {

--- a/docs/RC/OnRemoteControlSettings/index.md
+++ b/docs/RC/OnRemoteControlSettings/index.md
@@ -34,7 +34,9 @@ OnRemoteControlSettings disabling RC
 ![OnRemoteControlSettings disabling RC](./assets/OnRemoteControlSettings_disablingRC.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 
 ```json
 {

--- a/docs/RC/OnRemoteControlSettings/index.md
+++ b/docs/RC/OnRemoteControlSettings/index.md
@@ -34,7 +34,7 @@ OnRemoteControlSettings disabling RC
 ![OnRemoteControlSettings disabling RC](./assets/OnRemoteControlSettings_disablingRC.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 
 ```json
 {

--- a/docs/RC/SetGlobalProperties/index.md
+++ b/docs/RC/SetGlobalProperties/index.md
@@ -41,7 +41,9 @@ SetGlobalProperties
 ![SetGlobalProperties](assets/RC_SetGlobalProperties.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -64,7 +66,7 @@ SetGlobalProperties
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -78,7 +80,7 @@ SetGlobalProperties
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/RC/SetGlobalProperties/index.md
+++ b/docs/RC/SetGlobalProperties/index.md
@@ -30,6 +30,7 @@ The driver's application should be able to control any free module that is allow
 
 
 ### Response
+
 #### Parameters
 This RPC has no additional parameter requirements
 
@@ -40,7 +41,7 @@ SetGlobalProperties
 ![SetGlobalProperties](assets/RC_SetGlobalProperties.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -63,7 +64,7 @@ SetGlobalProperties
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -77,7 +78,7 @@ SetGlobalProperties
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/RC/SetGlobalProperties/index.md
+++ b/docs/RC/SetGlobalProperties/index.md
@@ -41,7 +41,7 @@ SetGlobalProperties
 ![SetGlobalProperties](assets/RC_SetGlobalProperties.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -64,7 +64,7 @@ SetGlobalProperties
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -78,7 +78,7 @@ SetGlobalProperties
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/RC/SetInteriorVehicleData/index.md
+++ b/docs/RC/SetInteriorVehicleData/index.md
@@ -47,7 +47,7 @@ SetInteriorvehicleData-READ_ONLY
 ![SetInteriorvehicleData READ_ONLY](assets/setInteriorVehicleData_READ_ONLY.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -81,7 +81,7 @@ SetInteriorvehicleData-READ_ONLY
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -115,7 +115,7 @@ SetInteriorvehicleData-READ_ONLY
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/RC/SetInteriorVehicleData/index.md
+++ b/docs/RC/SetInteriorVehicleData/index.md
@@ -47,7 +47,9 @@ SetInteriorvehicleData-READ_ONLY
 ![SetInteriorvehicleData READ_ONLY](assets/setInteriorVehicleData_READ_ONLY.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -81,7 +83,7 @@ SetInteriorvehicleData-READ_ONLY
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -115,7 +117,7 @@ SetInteriorvehicleData-READ_ONLY
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/RC/SetInteriorVehicleData/index.md
+++ b/docs/RC/SetInteriorVehicleData/index.md
@@ -47,7 +47,7 @@ SetInteriorvehicleData-READ_ONLY
 ![SetInteriorvehicleData READ_ONLY](assets/setInteriorVehicleData_READ_ONLY.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -81,7 +81,7 @@ SetInteriorvehicleData-READ_ONLY
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -115,7 +115,7 @@ SetInteriorvehicleData-READ_ONLY
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/SDL/ActivateApp/index.md
+++ b/docs/SDL/ActivateApp/index.md
@@ -81,7 +81,9 @@ ActivateApp using App Launching
 ![ActivateApp](./assets/ActivateAppAppLaunch.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -95,7 +97,7 @@ ActivateApp using App Launching
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -113,7 +115,7 @@ ActivateApp using App Launching
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/SDL/ActivateApp/index.md
+++ b/docs/SDL/ActivateApp/index.md
@@ -81,7 +81,7 @@ ActivateApp using App Launching
 ![ActivateApp](./assets/ActivateAppAppLaunch.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -94,7 +94,8 @@ ActivateApp using App Launching
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -112,7 +113,7 @@ ActivateApp using App Launching
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/SDL/ActivateApp/index.md
+++ b/docs/SDL/ActivateApp/index.md
@@ -81,7 +81,7 @@ ActivateApp using App Launching
 ![ActivateApp](./assets/ActivateAppAppLaunch.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -95,7 +95,7 @@ ActivateApp using App Launching
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -113,7 +113,7 @@ ActivateApp using App Launching
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/SDL/AddStatisticsInfo/index.md
+++ b/docs/SDL/AddStatisticsInfo/index.md
@@ -17,7 +17,9 @@ Purpose
 |:---|:---|:--------|:---------|
 |statisticType|[Common.StatisticsType](../../common/enums/#statisticstype)|true||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 
 ```json
 {

--- a/docs/SDL/AddStatisticsInfo/index.md
+++ b/docs/SDL/AddStatisticsInfo/index.md
@@ -17,7 +17,7 @@ Purpose
 |:---|:---|:--------|:---------|
 |statisticType|[Common.StatisticsType](../../common/enums/#statisticstype)|true||
 
-#### JSON Example Notification
+### JSON Example Notification
 
 ```json
 {

--- a/docs/SDL/AddStatisticsInfo/index.md
+++ b/docs/SDL/AddStatisticsInfo/index.md
@@ -17,7 +17,7 @@ Purpose
 |:---|:---|:--------|:---------|
 |statisticType|[Common.StatisticsType](../../common/enums/#statisticstype)|true||
 
-### JSON Example Notification
+### Example Notification
 
 ```json
 {

--- a/docs/SDL/GetListOfPermissions/index.md
+++ b/docs/SDL/GetListOfPermissions/index.md
@@ -68,7 +68,7 @@ GetListOfPermissions provide  External UCS Status to HMI
 Possible Layout - ExternalConsentStatus
 ![GetListOfPermissions](./assets/PossibleLayoutExternalConsentStatus.png)
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -81,7 +81,8 @@ Possible Layout - ExternalConsentStatus
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -113,7 +114,7 @@ Possible Layout - ExternalConsentStatus
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/SDL/GetListOfPermissions/index.md
+++ b/docs/SDL/GetListOfPermissions/index.md
@@ -68,7 +68,9 @@ GetListOfPermissions provide  External UCS Status to HMI
 Possible Layout - ExternalConsentStatus
 ![GetListOfPermissions](./assets/PossibleLayoutExternalConsentStatus.png)
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -82,7 +84,7 @@ Possible Layout - ExternalConsentStatus
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -114,7 +116,7 @@ Possible Layout - ExternalConsentStatus
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/SDL/GetListOfPermissions/index.md
+++ b/docs/SDL/GetListOfPermissions/index.md
@@ -68,7 +68,7 @@ GetListOfPermissions provide  External UCS Status to HMI
 Possible Layout - ExternalConsentStatus
 ![GetListOfPermissions](./assets/PossibleLayoutExternalConsentStatus.png)
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -82,7 +82,7 @@ Possible Layout - ExternalConsentStatus
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -114,7 +114,7 @@ Possible Layout - ExternalConsentStatus
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/SDL/GetPolicyConfigurationData/index.md
+++ b/docs/SDL/GetPolicyConfigurationData/index.md
@@ -48,7 +48,7 @@ GetPolicyConfigurationData
 ![GetPolicyConfigurationData](./assets/GetPolicyConfigurationData.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -62,7 +62,8 @@ GetPolicyConfigurationData
 	}
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -79,7 +80,7 @@ GetPolicyConfigurationData
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/SDL/GetPolicyConfigurationData/index.md
+++ b/docs/SDL/GetPolicyConfigurationData/index.md
@@ -48,7 +48,7 @@ GetPolicyConfigurationData
 ![GetPolicyConfigurationData](./assets/GetPolicyConfigurationData.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -63,7 +63,7 @@ GetPolicyConfigurationData
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -80,7 +80,7 @@ GetPolicyConfigurationData
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/SDL/GetPolicyConfigurationData/index.md
+++ b/docs/SDL/GetPolicyConfigurationData/index.md
@@ -48,7 +48,9 @@ GetPolicyConfigurationData
 ![GetPolicyConfigurationData](./assets/GetPolicyConfigurationData.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -63,7 +65,7 @@ GetPolicyConfigurationData
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -80,7 +82,7 @@ GetPolicyConfigurationData
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/SDL/GetStatusUpdate/index.md
+++ b/docs/SDL/GetStatusUpdate/index.md
@@ -36,7 +36,7 @@ GetStatusUpdate
 ![GetStatusUpdate](./assets/GetStatusUpdate.jpg)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -46,7 +46,7 @@ GetStatusUpdate
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -61,7 +61,7 @@ GetStatusUpdate
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/SDL/GetStatusUpdate/index.md
+++ b/docs/SDL/GetStatusUpdate/index.md
@@ -36,7 +36,7 @@ GetStatusUpdate
 ![GetStatusUpdate](./assets/GetStatusUpdate.jpg)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -45,7 +45,8 @@ GetStatusUpdate
   "method" : "SDL.GetStatusUpdate"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -60,7 +61,7 @@ GetStatusUpdate
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/SDL/GetStatusUpdate/index.md
+++ b/docs/SDL/GetStatusUpdate/index.md
@@ -36,7 +36,9 @@ GetStatusUpdate
 ![GetStatusUpdate](./assets/GetStatusUpdate.jpg)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -46,7 +48,7 @@ GetStatusUpdate
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -61,7 +63,7 @@ GetStatusUpdate
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/SDL/GetUserFriendlyMessage/index.md
+++ b/docs/SDL/GetUserFriendlyMessage/index.md
@@ -80,7 +80,7 @@ GetUserFriendlyMessage for device consent
 ![GetUserFriendlyMessage](./assets/GetUserFriendlyMessage.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -95,7 +95,8 @@ GetUserFriendlyMessage for device consent
 
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -114,7 +115,7 @@ GetUserFriendlyMessage for device consent
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/SDL/GetUserFriendlyMessage/index.md
+++ b/docs/SDL/GetUserFriendlyMessage/index.md
@@ -80,7 +80,9 @@ GetUserFriendlyMessage for device consent
 ![GetUserFriendlyMessage](./assets/GetUserFriendlyMessage.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -96,7 +98,7 @@ GetUserFriendlyMessage for device consent
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -115,7 +117,7 @@ GetUserFriendlyMessage for device consent
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/SDL/GetUserFriendlyMessage/index.md
+++ b/docs/SDL/GetUserFriendlyMessage/index.md
@@ -80,7 +80,7 @@ GetUserFriendlyMessage for device consent
 ![GetUserFriendlyMessage](./assets/GetUserFriendlyMessage.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -96,7 +96,7 @@ GetUserFriendlyMessage for device consent
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -115,7 +115,7 @@ GetUserFriendlyMessage for device consent
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/SDL/OnAllowSDLFunctionality/index.md
+++ b/docs/SDL/OnAllowSDLFunctionality/index.md
@@ -53,7 +53,9 @@ The User does NOT consent the device.
 ![OnAllowSDLFunctionality](./assets/User_does_not_consent_the_device1.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
 	"jsonrpc" : "2.0",

--- a/docs/SDL/OnAllowSDLFunctionality/index.md
+++ b/docs/SDL/OnAllowSDLFunctionality/index.md
@@ -53,7 +53,7 @@ The User does NOT consent the device.
 ![OnAllowSDLFunctionality](./assets/User_does_not_consent_the_device1.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
 	"jsonrpc" : "2.0",

--- a/docs/SDL/OnAllowSDLFunctionality/index.md
+++ b/docs/SDL/OnAllowSDLFunctionality/index.md
@@ -53,7 +53,7 @@ The User does NOT consent the device.
 ![OnAllowSDLFunctionality](./assets/User_does_not_consent_the_device1.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
 	"jsonrpc" : "2.0",

--- a/docs/SDL/OnAppPermissionChanged/index.md
+++ b/docs/SDL/OnAppPermissionChanged/index.md
@@ -57,7 +57,7 @@ OnAppPermissionChanged with consent required
 ![OnAppPermissionChanged](./assets/OnAppPermissionChanged.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/SDL/OnAppPermissionChanged/index.md
+++ b/docs/SDL/OnAppPermissionChanged/index.md
@@ -57,7 +57,7 @@ OnAppPermissionChanged with consent required
 ![OnAppPermissionChanged](./assets/OnAppPermissionChanged.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/SDL/OnAppPermissionChanged/index.md
+++ b/docs/SDL/OnAppPermissionChanged/index.md
@@ -57,7 +57,9 @@ OnAppPermissionChanged with consent required
 ![OnAppPermissionChanged](./assets/OnAppPermissionChanged.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/SDL/OnAppPermissionConsent/index.md
+++ b/docs/SDL/OnAppPermissionConsent/index.md
@@ -43,7 +43,7 @@ c) SDL  uses `OnAppPermissionConsent` value (ON/OFF) received from HMI through i
 |externalConsentStatus|[Common.ExternalConsentStatus](../../common/structs/#externalconsentstatus)|false|array: true <br>minsize: 1<br>maxsize: 100|
 |source|[Common.ConsentSource](../../common/enums/#consentsource)|true||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/SDL/OnAppPermissionConsent/index.md
+++ b/docs/SDL/OnAppPermissionConsent/index.md
@@ -43,6 +43,17 @@ c) SDL  uses `OnAppPermissionConsent` value (ON/OFF) received from HMI through i
 |externalConsentStatus|[Common.ExternalConsentStatus](../../common/structs/#externalconsentstatus)|false|array: true <br>minsize: 1<br>maxsize: 100|
 |source|[Common.ConsentSource](../../common/enums/#consentsource)|true||
 
+### Sequence Diagrams
+
+|||
+OnAppPermissionConsent
+![OnAppPermissionConsent1](./assets/OnAppPermissionConsent.png)
+|||
+|||
+OnAppPermissionConsent (id<->name dependency)
+![OnAppPermissionConsent](./assets/OnAppPermissionConsent2.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Notification
@@ -64,15 +75,3 @@ c) SDL  uses `OnAppPermissionConsent` value (ON/OFF) received from HMI through i
   }
 }
 ```
-
-### Sequence Diagrams
-
-|||
-OnAppPermissionConsent
-![OnAppPermissionConsent1](./assets/OnAppPermissionConsent.png)
-|||
-|||
-OnAppPermissionConsent (id<->name dependency)
-![OnAppPermissionConsent](./assets/OnAppPermissionConsent2.png)
-|||
-

--- a/docs/SDL/OnAppPermissionConsent/index.md
+++ b/docs/SDL/OnAppPermissionConsent/index.md
@@ -43,7 +43,7 @@ c) SDL  uses `OnAppPermissionConsent` value (ON/OFF) received from HMI through i
 |externalConsentStatus|[Common.ExternalConsentStatus](../../common/structs/#externalconsentstatus)|false|array: true <br>minsize: 1<br>maxsize: 100|
 |source|[Common.ConsentSource](../../common/enums/#consentsource)|true||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/SDL/OnAppPermissionConsent/index.md
+++ b/docs/SDL/OnAppPermissionConsent/index.md
@@ -1,8 +1,6 @@
 ## OnAppPermissionConsent
 
 
-### Notification
-
 Type
 : Notification  
 
@@ -33,6 +31,8 @@ a) SDL ignores all invalid notifications which come from HMI (invalid JSON, inva
 b) `ExternalConsentStatus` either user_dissalows or user_allows applications functional groupings depending on predefined settings in policy table.  
 c) SDL  uses `OnAppPermissionConsent` value (ON/OFF) received from HMI through ignition cycles until this value is changed by corresponding notification from HMI.
 !!!
+
+### Notification
 
 #### Parameters
 

--- a/docs/SDL/OnAppPermissionConsent/index.md
+++ b/docs/SDL/OnAppPermissionConsent/index.md
@@ -43,7 +43,9 @@ c) SDL  uses `OnAppPermissionConsent` value (ON/OFF) received from HMI through i
 |externalConsentStatus|[Common.ExternalConsentStatus](../../common/structs/#externalconsentstatus)|false|array: true <br>minsize: 1<br>maxsize: 100|
 |source|[Common.ConsentSource](../../common/enums/#consentsource)|true||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/SDL/OnDeviceStateChanged/index.md
+++ b/docs/SDL/OnDeviceStateChanged/index.md
@@ -20,6 +20,8 @@ SDL ignores all invalid notifications which come from HMI (invalid JSON, invalid
 Unpairing of the device is NOT a trigger for new PTU sequence.
 !!!
 
+### Notification
+
 #### Parameters
 
 |Name|Type|Mandatory|Additional|
@@ -28,7 +30,7 @@ Unpairing of the device is NOT a trigger for new PTU sequence.
 |deviceInternalId|String|true|minlength: 0<br>maxlength: 500|
 |deviceId|[Common.DeviceInfo](../../common/structs/#deviceinfo)|false||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/SDL/OnDeviceStateChanged/index.md
+++ b/docs/SDL/OnDeviceStateChanged/index.md
@@ -30,7 +30,7 @@ Unpairing of the device is NOT a trigger for new PTU sequence.
 |deviceInternalId|String|true|minlength: 0<br>maxlength: 500|
 |deviceId|[Common.DeviceInfo](../../common/structs/#deviceinfo)|false||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/SDL/OnDeviceStateChanged/index.md
+++ b/docs/SDL/OnDeviceStateChanged/index.md
@@ -30,7 +30,9 @@ Unpairing of the device is NOT a trigger for new PTU sequence.
 |deviceInternalId|String|true|minlength: 0<br>maxlength: 500|
 |deviceId|[Common.DeviceInfo](../../common/structs/#deviceinfo)|false||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/SDL/OnPolicyUpdate/index.md
+++ b/docs/SDL/OnPolicyUpdate/index.md
@@ -28,7 +28,9 @@ Currently this notification is not used in any HMI workflows, but in case of nec
 #### Parameters
 This RPC has no additional parameter requirements.
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
 	"jsonrpc" : "2.0",

--- a/docs/SDL/OnPolicyUpdate/index.md
+++ b/docs/SDL/OnPolicyUpdate/index.md
@@ -28,7 +28,7 @@ Currently this notification is not used in any HMI workflows, but in case of nec
 #### Parameters
 This RPC has no additional parameter requirements.
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
 	"jsonrpc" : "2.0",

--- a/docs/SDL/OnPolicyUpdate/index.md
+++ b/docs/SDL/OnPolicyUpdate/index.md
@@ -23,10 +23,12 @@ Currently this notification is not used in any HMI workflows, but in case of nec
    - In case SDL receives `SDL.OnPolicyUpdate` notification from HMI, SDL PoliciesManager must start the procedure of Policy Table Update (that is, create PT Snapshot, send it to HMI for encryption, and etc. what is defined by related requirements).
 !!!
 
+### Notification
+
 #### Parameters
 This RPC has no additional parameter requirements.
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
 	"jsonrpc" : "2.0",

--- a/docs/SDL/OnPolicyUpdate/index.md
+++ b/docs/SDL/OnPolicyUpdate/index.md
@@ -28,6 +28,13 @@ Currently this notification is not used in any HMI workflows, but in case of nec
 #### Parameters
 This RPC has no additional parameter requirements.
 
+### Sequence Diagrams
+
+|||
+Policy Table Update flow
+![OnPolicyUpdate](./assets/OnPolicyUpdate.jpg)
+|||
+
 ### JSON Message Examples
 
 #### Example Notification
@@ -37,12 +44,3 @@ This RPC has no additional parameter requirements.
 	"method" : "SDL.OnPolicyUpdate"
 }
 ```
-
-### Sequence Diagrams
-
-|||
-Policy Table Update flow
-![OnPolicyUpdate](./assets/OnPolicyUpdate.jpg)
-|||
-
-

--- a/docs/SDL/OnReceivedPolicyUpdate/index.md
+++ b/docs/SDL/OnReceivedPolicyUpdate/index.md
@@ -45,7 +45,7 @@ SDL.OnReceivedPolicyUpdate in "Proprietary" Policy Table Update Flow
 ![Proprietary PTU](./assets/Proprietary_PTU_flow_.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
 	"id" : 176,

--- a/docs/SDL/OnReceivedPolicyUpdate/index.md
+++ b/docs/SDL/OnReceivedPolicyUpdate/index.md
@@ -45,8 +45,7 @@ SDL.OnReceivedPolicyUpdate in "Proprietary" Policy Table Update Flow
 ![Proprietary PTU](./assets/Proprietary_PTU_flow_.png)
 |||
 
-
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
 	"id" : 176,

--- a/docs/SDL/OnReceivedPolicyUpdate/index.md
+++ b/docs/SDL/OnReceivedPolicyUpdate/index.md
@@ -45,7 +45,9 @@ SDL.OnReceivedPolicyUpdate in "Proprietary" Policy Table Update Flow
 ![Proprietary PTU](./assets/Proprietary_PTU_flow_.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
 	"id" : 176,

--- a/docs/SDL/OnSDLConsentNeeded/index.md
+++ b/docs/SDL/OnSDLConsentNeeded/index.md
@@ -16,7 +16,9 @@ The notification is applicable only for the case when the device is consented by
 3) Display the 'device consent' dialog after getting _SDL.GetUserFriendlyMessages_response_ from SDL.   
 4) Send _OnAllowSDLFunctionality_ (true or false) after and depending on User's choice on HMI.   
 !!!
- 
+
+### Notification
+
 #### Parameters
 
 |Name|Type|Mandatory|Additional|
@@ -35,7 +37,7 @@ The User consents the device
 ![OnSDLConsentNeeded](./assets/User_consents_the_device2.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
 	"jsonrpc": "2.0",

--- a/docs/SDL/OnSDLConsentNeeded/index.md
+++ b/docs/SDL/OnSDLConsentNeeded/index.md
@@ -37,7 +37,9 @@ The User consents the device
 ![OnSDLConsentNeeded](./assets/User_consents_the_device2.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
 	"jsonrpc": "2.0",

--- a/docs/SDL/OnSDLConsentNeeded/index.md
+++ b/docs/SDL/OnSDLConsentNeeded/index.md
@@ -37,7 +37,7 @@ The User consents the device
 ![OnSDLConsentNeeded](./assets/User_consents_the_device2.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
 	"jsonrpc": "2.0",

--- a/docs/SDL/OnStatusUpdate/index.md
+++ b/docs/SDL/OnStatusUpdate/index.md
@@ -32,7 +32,7 @@ SDL operates with the following PTU statuses:
 |:---|:---|:--------|:---------|
 |status|[Common.UpdateResult](../../common/enums/#updateresult)|true||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/SDL/OnStatusUpdate/index.md
+++ b/docs/SDL/OnStatusUpdate/index.md
@@ -32,7 +32,7 @@ SDL operates with the following PTU statuses:
 |:---|:---|:--------|:---------|
 |status|[Common.UpdateResult](../../common/enums/#updateresult)|true||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/SDL/OnStatusUpdate/index.md
+++ b/docs/SDL/OnStatusUpdate/index.md
@@ -32,6 +32,12 @@ SDL operates with the following PTU statuses:
 |:---|:---|:--------|:---------|
 |status|[Common.UpdateResult](../../common/enums/#updateresult)|true||
 
+### Sequence Diagrams
+|||
+SDL.OnStatusUpdate in "Proprietary" Policy Table Update Flow
+![OnStatusUpdate](./assets/OnStatusUpdate_in_Proprietary_PTU_flow.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Notification
@@ -45,9 +51,3 @@ SDL operates with the following PTU statuses:
   }
 }
 ```
-
-### Sequence Diagrams
-|||
-SDL.OnStatusUpdate in "Proprietary" Policy Table Update Flow
-![OnStatusUpdate](./assets/OnStatusUpdate_in_Proprietary_PTU_flow.png)
-|||

--- a/docs/SDL/OnStatusUpdate/index.md
+++ b/docs/SDL/OnStatusUpdate/index.md
@@ -32,7 +32,9 @@ SDL operates with the following PTU statuses:
 |:---|:---|:--------|:---------|
 |status|[Common.UpdateResult](../../common/enums/#updateresult)|true||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/SDL/OnSystemError/index.md
+++ b/docs/SDL/OnSystemError/index.md
@@ -17,7 +17,7 @@ Purpose
 |:---|:---|:--------|:---------|
 |error|[Common.SystemError](../../common/enums/#systemerror)|true||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc": "2.0",

--- a/docs/SDL/OnSystemError/index.md
+++ b/docs/SDL/OnSystemError/index.md
@@ -17,7 +17,9 @@ Purpose
 |:---|:---|:--------|:---------|
 |error|[Common.SystemError](../../common/enums/#systemerror)|true||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc": "2.0",

--- a/docs/SDL/OnSystemError/index.md
+++ b/docs/SDL/OnSystemError/index.md
@@ -17,7 +17,7 @@ Purpose
 |:---|:---|:--------|:---------|
 |error|[Common.SystemError](../../common/enums/#systemerror)|true||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc": "2.0",

--- a/docs/SDL/UpdateSDL/index.md
+++ b/docs/SDL/UpdateSDL/index.md
@@ -59,7 +59,7 @@ UpdateSDL - PROPRIETARY Policy Table Update Flow
 ![UpdateSDL](./assets/Proprietary_PTU_flow_.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -69,7 +69,7 @@ UpdateSDL - PROPRIETARY Policy Table Update Flow
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -84,7 +84,7 @@ UpdateSDL - PROPRIETARY Policy Table Update Flow
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/SDL/UpdateSDL/index.md
+++ b/docs/SDL/UpdateSDL/index.md
@@ -59,7 +59,9 @@ UpdateSDL - PROPRIETARY Policy Table Update Flow
 ![UpdateSDL](./assets/Proprietary_PTU_flow_.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -69,7 +71,7 @@ UpdateSDL - PROPRIETARY Policy Table Update Flow
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -84,7 +86,7 @@ UpdateSDL - PROPRIETARY Policy Table Update Flow
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/SDL/UpdateSDL/index.md
+++ b/docs/SDL/UpdateSDL/index.md
@@ -1,7 +1,5 @@
 ## UpdateSDL
 
-### Notification
-
 Type
 : Function
 

--- a/docs/SDL/UpdateSDL/index.md
+++ b/docs/SDL/UpdateSDL/index.md
@@ -58,7 +58,8 @@ UpdateSDL UPDATE_NEEDED - EXTERNAL_PROPRIETARY Policy Table Update Flow
 UpdateSDL - PROPRIETARY Policy Table Update Flow
 ![UpdateSDL](./assets/Proprietary_PTU_flow_.png)
 |||
-### Example Request
+
+### JSON Example Request
 
 ```json
 {
@@ -68,7 +69,7 @@ UpdateSDL - PROPRIETARY Policy Table Update Flow
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -83,7 +84,7 @@ UpdateSDL - PROPRIETARY Policy Table Update Flow
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/TTS/ChangeRegistration/index.md
+++ b/docs/TTS/ChangeRegistration/index.md
@@ -31,7 +31,7 @@ ChangeRegistration after OnAppRegistered
 ![ChangeRegistration](./assets/ChangeRegistration.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -45,7 +45,8 @@ ChangeRegistration after OnAppRegistered
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -59,7 +60,7 @@ ChangeRegistration after OnAppRegistered
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/TTS/ChangeRegistration/index.md
+++ b/docs/TTS/ChangeRegistration/index.md
@@ -31,7 +31,9 @@ ChangeRegistration after OnAppRegistered
 ![ChangeRegistration](./assets/ChangeRegistration.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -46,7 +48,7 @@ ChangeRegistration after OnAppRegistered
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -60,7 +62,7 @@ ChangeRegistration after OnAppRegistered
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/TTS/ChangeRegistration/index.md
+++ b/docs/TTS/ChangeRegistration/index.md
@@ -31,7 +31,7 @@ ChangeRegistration after OnAppRegistered
 ![ChangeRegistration](./assets/ChangeRegistration.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -46,7 +46,7 @@ ChangeRegistration after OnAppRegistered
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -60,7 +60,7 @@ ChangeRegistration after OnAppRegistered
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/TTS/GetCapabilities/index.md
+++ b/docs/TTS/GetCapabilities/index.md
@@ -59,7 +59,7 @@ GetCapabilities
 ![GetCapabilities](./assets/GetCapabilities.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -69,7 +69,7 @@ GetCapabilities
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -85,7 +85,7 @@ GetCapabilities
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/TTS/GetCapabilities/index.md
+++ b/docs/TTS/GetCapabilities/index.md
@@ -59,7 +59,7 @@ GetCapabilities
 ![GetCapabilities](./assets/GetCapabilities.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -68,7 +68,8 @@ GetCapabilities
   "method" : "TTS.GetCapabilities"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -84,7 +85,7 @@ GetCapabilities
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/TTS/GetCapabilities/index.md
+++ b/docs/TTS/GetCapabilities/index.md
@@ -59,7 +59,9 @@ GetCapabilities
 ![GetCapabilities](./assets/GetCapabilities.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -69,7 +71,7 @@ GetCapabilities
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -85,7 +87,7 @@ GetCapabilities
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/TTS/GetLanguage/index.md
+++ b/docs/TTS/GetLanguage/index.md
@@ -29,7 +29,7 @@ GetLanguage
 ![GetLanguage](./assets/GetLanguage.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -38,7 +38,8 @@ GetLanguage
   "method" : "TTS.GetLanguage"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -53,7 +54,7 @@ GetLanguage
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/TTS/GetLanguage/index.md
+++ b/docs/TTS/GetLanguage/index.md
@@ -29,7 +29,7 @@ GetLanguage
 ![GetLanguage](./assets/GetLanguage.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -39,7 +39,7 @@ GetLanguage
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -54,7 +54,7 @@ GetLanguage
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/TTS/GetLanguage/index.md
+++ b/docs/TTS/GetLanguage/index.md
@@ -29,7 +29,9 @@ GetLanguage
 ![GetLanguage](./assets/GetLanguage.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -39,7 +41,7 @@ GetLanguage
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -54,7 +56,7 @@ GetLanguage
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/TTS/GetSupportedLanguages/index.md
+++ b/docs/TTS/GetSupportedLanguages/index.md
@@ -29,7 +29,9 @@ GetSupportedLanguages
 ![GetSupportedLanguages](./assets/GetSupportedLanguages.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -39,7 +41,7 @@ GetSupportedLanguages
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -54,7 +56,7 @@ GetSupportedLanguages
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/TTS/GetSupportedLanguages/index.md
+++ b/docs/TTS/GetSupportedLanguages/index.md
@@ -29,7 +29,7 @@ GetSupportedLanguages
 ![GetSupportedLanguages](./assets/GetSupportedLanguages.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -38,7 +38,8 @@ GetSupportedLanguages
   "method" : "TTS.GetSupportedLanguages"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -53,7 +54,7 @@ GetSupportedLanguages
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/TTS/GetSupportedLanguages/index.md
+++ b/docs/TTS/GetSupportedLanguages/index.md
@@ -29,7 +29,7 @@ GetSupportedLanguages
 ![GetSupportedLanguages](./assets/GetSupportedLanguages.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -39,7 +39,7 @@ GetSupportedLanguages
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -54,7 +54,7 @@ GetSupportedLanguages
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/TTS/IsReady/index.md
+++ b/docs/TTS/IsReady/index.md
@@ -44,7 +44,7 @@ IsReady
 ![IsReady](./assets/IsReady.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -53,7 +53,8 @@ IsReady
   "method" : "TTS.IsReady"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -68,7 +69,7 @@ IsReady
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/TTS/IsReady/index.md
+++ b/docs/TTS/IsReady/index.md
@@ -44,7 +44,9 @@ IsReady
 ![IsReady](./assets/IsReady.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -54,7 +56,7 @@ IsReady
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -69,7 +71,7 @@ IsReady
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/TTS/IsReady/index.md
+++ b/docs/TTS/IsReady/index.md
@@ -44,7 +44,7 @@ IsReady
 ![IsReady](./assets/IsReady.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -54,7 +54,7 @@ IsReady
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -69,7 +69,7 @@ IsReady
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/TTS/OnLanguageChange/index.md
+++ b/docs/TTS/OnLanguageChange/index.md
@@ -23,7 +23,9 @@ OnLanguageChange
 ![OnLanguageChange](./assets/OnLanguageChange.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/TTS/OnLanguageChange/index.md
+++ b/docs/TTS/OnLanguageChange/index.md
@@ -23,7 +23,7 @@ OnLanguageChange
 ![OnLanguageChange](./assets/OnLanguageChange.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/TTS/OnLanguageChange/index.md
+++ b/docs/TTS/OnLanguageChange/index.md
@@ -23,7 +23,7 @@ OnLanguageChange
 ![OnLanguageChange](./assets/OnLanguageChange.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/TTS/OnResetTimeout/index.md
+++ b/docs/TTS/OnResetTimeout/index.md
@@ -28,7 +28,7 @@ OnResetTimeout for Speak GENERIC_ERROR
 ![OnResetTimeout](./assets/OnResetTimeoutGenericError.jpg)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/TTS/OnResetTimeout/index.md
+++ b/docs/TTS/OnResetTimeout/index.md
@@ -28,7 +28,9 @@ OnResetTimeout for Speak GENERIC_ERROR
 ![OnResetTimeout](./assets/OnResetTimeoutGenericError.jpg)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/TTS/OnResetTimeout/index.md
+++ b/docs/TTS/OnResetTimeout/index.md
@@ -28,7 +28,7 @@ OnResetTimeout for Speak GENERIC_ERROR
 ![OnResetTimeout](./assets/OnResetTimeoutGenericError.jpg)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/TTS/SetGlobalProperties/index.md
+++ b/docs/TTS/SetGlobalProperties/index.md
@@ -40,7 +40,7 @@ SetGlobalProperties request with VRHelp and HelpPrompt params
 ![SetGlobalProperties](./assets/SetGlobalProperties_VRHelp_and_HelpPrompt.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -81,7 +81,7 @@ SetGlobalProperties request with VRHelp and HelpPrompt params
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -95,7 +95,7 @@ SetGlobalProperties request with VRHelp and HelpPrompt params
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/TTS/SetGlobalProperties/index.md
+++ b/docs/TTS/SetGlobalProperties/index.md
@@ -40,7 +40,9 @@ SetGlobalProperties request with VRHelp and HelpPrompt params
 ![SetGlobalProperties](./assets/SetGlobalProperties_VRHelp_and_HelpPrompt.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -81,7 +83,7 @@ SetGlobalProperties request with VRHelp and HelpPrompt params
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -95,7 +97,7 @@ SetGlobalProperties request with VRHelp and HelpPrompt params
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/TTS/SetGlobalProperties/index.md
+++ b/docs/TTS/SetGlobalProperties/index.md
@@ -12,7 +12,7 @@ Purpose
 ### Description
 SDL requests to set the values for the prompts to be spoken by TTS during the User's interaction with the application over head unit.
 
-### Request  
+### Request
 On receiving `AddCommand` with `CommandType = Command` before a custom `helpPrompt` is set by the application, SDL must send updated values of `helpPrompt` via TTS.SetGlobalProperties request to HMI.
 
 #### Parameters
@@ -40,7 +40,7 @@ SetGlobalProperties request with VRHelp and HelpPrompt params
 ![SetGlobalProperties](./assets/SetGlobalProperties_VRHelp_and_HelpPrompt.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -80,7 +80,8 @@ SetGlobalProperties request with VRHelp and HelpPrompt params
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -94,7 +95,7 @@ SetGlobalProperties request with VRHelp and HelpPrompt params
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/TTS/Speak/index.md
+++ b/docs/TTS/Speak/index.md
@@ -32,7 +32,7 @@ Speak
 ![Speak](./assets/Speak.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -52,7 +52,7 @@ Speak
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -66,7 +66,7 @@ Speak
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/TTS/Speak/index.md
+++ b/docs/TTS/Speak/index.md
@@ -32,7 +32,9 @@ Speak
 ![Speak](./assets/Speak.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -52,7 +54,7 @@ Speak
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -66,7 +68,7 @@ Speak
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/TTS/Speak/index.md
+++ b/docs/TTS/Speak/index.md
@@ -32,7 +32,7 @@ Speak
 ![Speak](./assets/Speak.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -51,7 +51,8 @@ Speak
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -65,7 +66,7 @@ Speak
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/TTS/Started/index.md
+++ b/docs/TTS/Started/index.md
@@ -25,7 +25,7 @@ Started during PerformInteraction
 ![Started](./assets/StartedFromPerformInteraction.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/TTS/Started/index.md
+++ b/docs/TTS/Started/index.md
@@ -25,42 +25,10 @@ Started during PerformInteraction
 ![Started](./assets/StartedFromPerformInteraction.png)
 |||
 
-### Example Request
-
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",
   "method" : "TTS.Started"
-}
-```
-### Example Response
-
-```json
-{
-  "id" : 37,
-  "jsonrpc" : "2.0",
-  "result" :
-  {
-    "code" : 0,
-    "method" : "TTS.Started"
-  }
-}
-```
-
-### Example Error
-
-```json
-{
-  "id" : 37,
-  "jsonrpc" : "2.0",
-  "error" :
-  {
-    "code" : 22,
-    "message" : "Something went wrong",
-    "data" :
-    {
-      "method" : "TTS.Started"
-    }
-  }
 }
 ```

--- a/docs/TTS/Started/index.md
+++ b/docs/TTS/Started/index.md
@@ -25,7 +25,9 @@ Started during PerformInteraction
 ![Started](./assets/StartedFromPerformInteraction.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/TTS/StopSpeaking/index.md
+++ b/docs/TTS/StopSpeaking/index.md
@@ -27,7 +27,7 @@ StopSpeaking
 ![StopSpeaking](./assets/StopSpeaking.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -37,7 +37,7 @@ StopSpeaking
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -51,7 +51,7 @@ StopSpeaking
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/TTS/StopSpeaking/index.md
+++ b/docs/TTS/StopSpeaking/index.md
@@ -27,7 +27,9 @@ StopSpeaking
 ![StopSpeaking](./assets/StopSpeaking.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -37,7 +39,7 @@ StopSpeaking
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -51,7 +53,7 @@ StopSpeaking
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/TTS/StopSpeaking/index.md
+++ b/docs/TTS/StopSpeaking/index.md
@@ -27,7 +27,7 @@ StopSpeaking
 ![StopSpeaking](./assets/StopSpeaking.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -36,7 +36,8 @@ StopSpeaking
   "method" : "TTS.StopSpeaking"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -50,7 +51,7 @@ StopSpeaking
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/TTS/Stopped/index.md
+++ b/docs/TTS/Stopped/index.md
@@ -21,7 +21,9 @@ Stopped after StopSpeaking from SDL
 ![Stopped](./assets/Stopped.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/TTS/Stopped/index.md
+++ b/docs/TTS/Stopped/index.md
@@ -21,42 +21,10 @@ Stopped after StopSpeaking from SDL
 ![Stopped](./assets/Stopped.png)
 |||
 
-### Example Request
-
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",
-  "method" : " TTS.Stopped"
-}
-```
-### Example Response
-
-```json
-{
-  "id" : 37,
-  "jsonrpc" : "2.0",
-  "result" :
-  {
-    "code" : 0,
-    "method" : "TTS.Stopped"
-  }
-}
-```
-
-### Example Error
-
-```json
-{
-  "id" : 37,
-  "jsonrpc" : "2.0",
-  "error" :
-  {
-    "code" : 22,
-    "message" : "Something went wrong",
-    "data" :
-    {
-      "method" : "TTS.Stopped"
-    }
-  }
+  "method" : "TTS.Stopped"
 }
 ```

--- a/docs/TTS/Stopped/index.md
+++ b/docs/TTS/Stopped/index.md
@@ -21,7 +21,7 @@ Stopped after StopSpeaking from SDL
 ![Stopped](./assets/Stopped.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/AddCommand/index.md
+++ b/docs/UI/AddCommand/index.md
@@ -82,7 +82,7 @@ AddCommand UI No Response, VR Succeeds
 ![AddCommand](./assets/AddCommandUINoResponseVRSuccess.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -108,7 +108,7 @@ AddCommand UI No Response, VR Succeeds
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -122,7 +122,7 @@ AddCommand UI No Response, VR Succeeds
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/AddCommand/index.md
+++ b/docs/UI/AddCommand/index.md
@@ -82,7 +82,9 @@ AddCommand UI No Response, VR Succeeds
 ![AddCommand](./assets/AddCommandUINoResponseVRSuccess.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -108,7 +110,7 @@ AddCommand UI No Response, VR Succeeds
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -122,7 +124,7 @@ AddCommand UI No Response, VR Succeeds
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/AddCommand/index.md
+++ b/docs/UI/AddCommand/index.md
@@ -82,7 +82,7 @@ AddCommand UI No Response, VR Succeeds
 ![AddCommand](./assets/AddCommandUINoResponseVRSuccess.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -107,7 +107,8 @@ AddCommand UI No Response, VR Succeeds
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -121,7 +122,7 @@ AddCommand UI No Response, VR Succeeds
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/AddSubMenu/index.md
+++ b/docs/UI/AddSubMenu/index.md
@@ -71,7 +71,9 @@ Add Sub Menu Rejected Limit Reached
 ![AddSubMenu](./assets/AddSubMenuLimit.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -91,7 +93,7 @@ Add Sub Menu Rejected Limit Reached
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -105,7 +107,7 @@ Add Sub Menu Rejected Limit Reached
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/AddSubMenu/index.md
+++ b/docs/UI/AddSubMenu/index.md
@@ -71,7 +71,7 @@ Add Sub Menu Rejected Limit Reached
 ![AddSubMenu](./assets/AddSubMenuLimit.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -90,7 +90,8 @@ Add Sub Menu Rejected Limit Reached
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -104,7 +105,7 @@ Add Sub Menu Rejected Limit Reached
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/AddSubMenu/index.md
+++ b/docs/UI/AddSubMenu/index.md
@@ -71,7 +71,7 @@ Add Sub Menu Rejected Limit Reached
 ![AddSubMenu](./assets/AddSubMenuLimit.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -91,7 +91,7 @@ Add Sub Menu Rejected Limit Reached
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -105,7 +105,7 @@ Add Sub Menu Rejected Limit Reached
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/Alert/index.md
+++ b/docs/UI/Alert/index.md
@@ -79,7 +79,7 @@ Alert BOTH UI Closed before TTS finishes Speaking
 ![Alert](./assets/AlertTTS.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -112,7 +112,8 @@ Alert BOTH UI Closed before TTS finishes Speaking
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -126,7 +127,7 @@ Alert BOTH UI Closed before TTS finishes Speaking
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/Alert/index.md
+++ b/docs/UI/Alert/index.md
@@ -79,7 +79,7 @@ Alert BOTH UI Closed before TTS finishes Speaking
 ![Alert](./assets/AlertTTS.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -113,7 +113,7 @@ Alert BOTH UI Closed before TTS finishes Speaking
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -127,7 +127,7 @@ Alert BOTH UI Closed before TTS finishes Speaking
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/Alert/index.md
+++ b/docs/UI/Alert/index.md
@@ -79,7 +79,9 @@ Alert BOTH UI Closed before TTS finishes Speaking
 ![Alert](./assets/AlertTTS.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -113,7 +115,7 @@ Alert BOTH UI Closed before TTS finishes Speaking
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -127,7 +129,7 @@ Alert BOTH UI Closed before TTS finishes Speaking
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/CancelInteraction/index.md
+++ b/docs/UI/CancelInteraction/index.md
@@ -19,6 +19,12 @@ Purpose
 |cancelID|Integer|false||
 |functionID|Integer|true|Can be any one of AlertID, PerformInteractionID, SliderID or ScrollableMessageID|
 
+### Response
+
+#### Parameters
+
+This RPC has no additional parameter requirements
+
 ### Sequence Diagrams
 |||
 CancelInteraction for any UI.Alert
@@ -35,7 +41,7 @@ CancelInteraction for specific UI.Alert using mismatched cancelID
 ![CancelInteraction](./assets/CancelInteractionSpecificAlertWrong.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -49,7 +55,8 @@ CancelInteraction for specific UI.Alert using mismatched cancelID
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -63,7 +70,7 @@ CancelInteraction for specific UI.Alert using mismatched cancelID
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/CancelInteraction/index.md
+++ b/docs/UI/CancelInteraction/index.md
@@ -41,7 +41,9 @@ CancelInteraction for specific UI.Alert using mismatched cancelID
 ![CancelInteraction](./assets/CancelInteractionSpecificAlertWrong.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -56,7 +58,7 @@ CancelInteraction for specific UI.Alert using mismatched cancelID
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -70,7 +72,7 @@ CancelInteraction for specific UI.Alert using mismatched cancelID
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/CancelInteraction/index.md
+++ b/docs/UI/CancelInteraction/index.md
@@ -41,7 +41,7 @@ CancelInteraction for specific UI.Alert using mismatched cancelID
 ![CancelInteraction](./assets/CancelInteractionSpecificAlertWrong.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -56,7 +56,7 @@ CancelInteraction for specific UI.Alert using mismatched cancelID
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -70,7 +70,7 @@ CancelInteraction for specific UI.Alert using mismatched cancelID
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/ChangeRegistration/index.md
+++ b/docs/UI/ChangeRegistration/index.md
@@ -33,7 +33,7 @@ ChangeRegistration
 ![ChangeRegistration](./assets/ChangeRegistration.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -48,7 +48,7 @@ ChangeRegistration
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -62,7 +62,7 @@ ChangeRegistration
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/ChangeRegistration/index.md
+++ b/docs/UI/ChangeRegistration/index.md
@@ -33,7 +33,7 @@ ChangeRegistration
 ![ChangeRegistration](./assets/ChangeRegistration.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -47,7 +47,8 @@ ChangeRegistration
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -61,7 +62,7 @@ ChangeRegistration
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/ChangeRegistration/index.md
+++ b/docs/UI/ChangeRegistration/index.md
@@ -33,7 +33,9 @@ ChangeRegistration
 ![ChangeRegistration](./assets/ChangeRegistration.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -48,7 +50,7 @@ ChangeRegistration
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -62,7 +64,7 @@ ChangeRegistration
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/ClosePopUp/index.md
+++ b/docs/UI/ClosePopUp/index.md
@@ -29,7 +29,7 @@ ClosePopUp for UI.PerformInteraction
 ![ClosePopUp](./assets/ClosePopUp.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -39,7 +39,7 @@ ClosePopUp for UI.PerformInteraction
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -53,7 +53,7 @@ ClosePopUp for UI.PerformInteraction
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/ClosePopUp/index.md
+++ b/docs/UI/ClosePopUp/index.md
@@ -29,7 +29,7 @@ ClosePopUp for UI.PerformInteraction
 ![ClosePopUp](./assets/ClosePopUp.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -38,7 +38,8 @@ ClosePopUp for UI.PerformInteraction
   "method" : "UI.ClosePopUp"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -52,7 +53,7 @@ ClosePopUp for UI.PerformInteraction
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/ClosePopUp/index.md
+++ b/docs/UI/ClosePopUp/index.md
@@ -29,7 +29,9 @@ ClosePopUp for UI.PerformInteraction
 ![ClosePopUp](./assets/ClosePopUp.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -39,7 +41,7 @@ ClosePopUp for UI.PerformInteraction
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -53,7 +55,7 @@ ClosePopUp for UI.PerformInteraction
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/CreateWindow/index.md
+++ b/docs/UI/CreateWindow/index.md
@@ -55,7 +55,7 @@ CreateWindow
 |||
 
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -73,7 +73,7 @@ CreateWindow
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -87,7 +87,7 @@ CreateWindow
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/CreateWindow/index.md
+++ b/docs/UI/CreateWindow/index.md
@@ -1,4 +1,4 @@
-## Create window
+## CreateWindow
 
 Type
 : Function
@@ -55,7 +55,7 @@ CreateWindow
 |||
 
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -73,7 +73,7 @@ CreateWindow
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -87,7 +87,7 @@ CreateWindow
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/CreateWindow/index.md
+++ b/docs/UI/CreateWindow/index.md
@@ -55,7 +55,9 @@ CreateWindow
 |||
 
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -73,7 +75,7 @@ CreateWindow
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -87,7 +89,7 @@ CreateWindow
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/DeleteCommand/index.md
+++ b/docs/UI/DeleteCommand/index.md
@@ -42,7 +42,9 @@ Delete Command Application Inactive
 ![DeleteCommand](./assets/DeleteCommandAppInactive.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -57,7 +59,7 @@ Delete Command Application Inactive
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -71,7 +73,7 @@ Delete Command Application Inactive
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/DeleteCommand/index.md
+++ b/docs/UI/DeleteCommand/index.md
@@ -42,7 +42,7 @@ Delete Command Application Inactive
 ![DeleteCommand](./assets/DeleteCommandAppInactive.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -56,7 +56,8 @@ Delete Command Application Inactive
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -70,7 +71,7 @@ Delete Command Application Inactive
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/DeleteCommand/index.md
+++ b/docs/UI/DeleteCommand/index.md
@@ -42,7 +42,7 @@ Delete Command Application Inactive
 ![DeleteCommand](./assets/DeleteCommandAppInactive.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -57,7 +57,7 @@ Delete Command Application Inactive
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -71,7 +71,7 @@ Delete Command Application Inactive
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/DeleteSubMenu/index.md
+++ b/docs/UI/DeleteSubMenu/index.md
@@ -38,7 +38,9 @@ Delete Sub Menu Containing Commands
 ![DeleteSubMenu](./assets/DeleteSubMenuWithCommands.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -53,7 +55,7 @@ Delete Sub Menu Containing Commands
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -67,7 +69,7 @@ Delete Sub Menu Containing Commands
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/DeleteSubMenu/index.md
+++ b/docs/UI/DeleteSubMenu/index.md
@@ -38,7 +38,7 @@ Delete Sub Menu Containing Commands
 ![DeleteSubMenu](./assets/DeleteSubMenuWithCommands.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -52,7 +52,8 @@ Delete Sub Menu Containing Commands
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -66,7 +67,7 @@ Delete Sub Menu Containing Commands
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/DeleteSubMenu/index.md
+++ b/docs/UI/DeleteSubMenu/index.md
@@ -38,7 +38,7 @@ Delete Sub Menu Containing Commands
 ![DeleteSubMenu](./assets/DeleteSubMenuWithCommands.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -53,7 +53,7 @@ Delete Sub Menu Containing Commands
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -67,7 +67,7 @@ Delete Sub Menu Containing Commands
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/DeleteWindow/index.md
+++ b/docs/UI/DeleteWindow/index.md
@@ -40,7 +40,7 @@ DeleteWindow
 |||
 
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -54,7 +54,7 @@ DeleteWindow
 }
 ```
 
-### Example Response
+### JSON Example Response
 
 ```json
 {
@@ -68,7 +68,7 @@ DeleteWindow
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/DeleteWindow/index.md
+++ b/docs/UI/DeleteWindow/index.md
@@ -40,7 +40,9 @@ DeleteWindow
 |||
 
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -54,7 +56,7 @@ DeleteWindow
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -68,7 +70,7 @@ DeleteWindow
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/DeleteWindow/index.md
+++ b/docs/UI/DeleteWindow/index.md
@@ -40,7 +40,7 @@ DeleteWindow
 |||
 
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -54,7 +54,7 @@ DeleteWindow
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -68,7 +68,7 @@ DeleteWindow
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/EndAudioPassThru/index.md
+++ b/docs/UI/EndAudioPassThru/index.md
@@ -31,7 +31,9 @@ EndAudioPassThru audio capturing already ended
 ![EndAudioPassThru](./assets/EndAudioPassThruTooLate.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -41,7 +43,7 @@ EndAudioPassThru audio capturing already ended
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -55,7 +57,7 @@ EndAudioPassThru audio capturing already ended
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/EndAudioPassThru/index.md
+++ b/docs/UI/EndAudioPassThru/index.md
@@ -31,7 +31,7 @@ EndAudioPassThru audio capturing already ended
 ![EndAudioPassThru](./assets/EndAudioPassThruTooLate.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -40,7 +40,8 @@ EndAudioPassThru audio capturing already ended
   "method" : "UI.EndAudioPassThru"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -54,7 +55,7 @@ EndAudioPassThru audio capturing already ended
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/EndAudioPassThru/index.md
+++ b/docs/UI/EndAudioPassThru/index.md
@@ -31,7 +31,7 @@ EndAudioPassThru audio capturing already ended
 ![EndAudioPassThru](./assets/EndAudioPassThruTooLate.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -41,7 +41,7 @@ EndAudioPassThru audio capturing already ended
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -55,7 +55,7 @@ EndAudioPassThru audio capturing already ended
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/GetCapabilities/index.md
+++ b/docs/UI/GetCapabilities/index.md
@@ -36,7 +36,7 @@ Get Capabilities
 ![GetCapabilities](./assets/GetCapabilities.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -46,7 +46,7 @@ Get Capabilities
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -125,7 +125,7 @@ Get Capabilities
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/GetCapabilities/index.md
+++ b/docs/UI/GetCapabilities/index.md
@@ -36,7 +36,7 @@ Get Capabilities
 ![GetCapabilities](./assets/GetCapabilities.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -45,7 +45,8 @@ Get Capabilities
   "method" : "UI.GetCapabilities"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -124,7 +125,7 @@ Get Capabilities
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/GetCapabilities/index.md
+++ b/docs/UI/GetCapabilities/index.md
@@ -36,7 +36,9 @@ Get Capabilities
 ![GetCapabilities](./assets/GetCapabilities.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -46,7 +48,7 @@ Get Capabilities
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -125,7 +127,7 @@ Get Capabilities
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/GetLanguage/index.md
+++ b/docs/UI/GetLanguage/index.md
@@ -29,7 +29,7 @@ GetLanguage
 ![GetLanguage](./assets/GetLanguage.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -39,7 +39,7 @@ GetLanguage
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -54,7 +54,7 @@ GetLanguage
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/GetLanguage/index.md
+++ b/docs/UI/GetLanguage/index.md
@@ -29,7 +29,7 @@ GetLanguage
 ![GetLanguage](./assets/GetLanguage.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -38,7 +38,8 @@ GetLanguage
   "method" : "UI.GetLanguage"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -53,7 +54,7 @@ GetLanguage
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/GetLanguage/index.md
+++ b/docs/UI/GetLanguage/index.md
@@ -29,7 +29,9 @@ GetLanguage
 ![GetLanguage](./assets/GetLanguage.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -39,7 +41,7 @@ GetLanguage
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -54,7 +56,7 @@ GetLanguage
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/GetSupportedLanguages/index.md
+++ b/docs/UI/GetSupportedLanguages/index.md
@@ -29,7 +29,7 @@ Get Supported Languages
 ![GetSupportedLanguages](./assets/GetSupportedLanguages.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -39,7 +39,7 @@ Get Supported Languages
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -54,7 +54,7 @@ Get Supported Languages
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/GetSupportedLanguages/index.md
+++ b/docs/UI/GetSupportedLanguages/index.md
@@ -29,7 +29,7 @@ Get Supported Languages
 ![GetSupportedLanguages](./assets/GetSupportedLanguages.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -38,7 +38,8 @@ Get Supported Languages
   "method" : "UI.GetSupportedLanguages"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -53,7 +54,7 @@ Get Supported Languages
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/GetSupportedLanguages/index.md
+++ b/docs/UI/GetSupportedLanguages/index.md
@@ -29,7 +29,9 @@ Get Supported Languages
 ![GetSupportedLanguages](./assets/GetSupportedLanguages.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -39,7 +41,7 @@ Get Supported Languages
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -54,7 +56,7 @@ Get Supported Languages
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/IsReady/index.md
+++ b/docs/UI/IsReady/index.md
@@ -44,7 +44,7 @@ UI Component Ready
 ![IsReady](./assets/IsReady.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -54,7 +54,7 @@ UI Component Ready
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -69,7 +69,7 @@ UI Component Ready
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/IsReady/index.md
+++ b/docs/UI/IsReady/index.md
@@ -44,7 +44,7 @@ UI Component Ready
 ![IsReady](./assets/IsReady.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -53,7 +53,8 @@ UI Component Ready
   "method" : "UI.IsReady"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -68,7 +69,7 @@ UI Component Ready
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/IsReady/index.md
+++ b/docs/UI/IsReady/index.md
@@ -44,7 +44,9 @@ UI Component Ready
 ![IsReady](./assets/IsReady.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -54,7 +56,7 @@ UI Component Ready
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -69,7 +71,7 @@ UI Component Ready
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/OnCommand/index.md
+++ b/docs/UI/OnCommand/index.md
@@ -32,7 +32,9 @@ OnCommand
 ![OnCommand](./assets/OnCommand.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnCommand/index.md
+++ b/docs/UI/OnCommand/index.md
@@ -32,7 +32,7 @@ OnCommand
 ![OnCommand](./assets/OnCommand.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnCommand/index.md
+++ b/docs/UI/OnCommand/index.md
@@ -32,7 +32,7 @@ OnCommand
 ![OnCommand](./assets/OnCommand.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnDriverDistraction/index.md
+++ b/docs/UI/OnDriverDistraction/index.md
@@ -37,7 +37,7 @@ OnDriverDistraction
 ![OnDriverDistraction](./assets/OnDriverDistraction.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnDriverDistraction/index.md
+++ b/docs/UI/OnDriverDistraction/index.md
@@ -37,7 +37,9 @@ OnDriverDistraction
 ![OnDriverDistraction](./assets/OnDriverDistraction.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnDriverDistraction/index.md
+++ b/docs/UI/OnDriverDistraction/index.md
@@ -37,8 +37,7 @@ OnDriverDistraction
 ![OnDriverDistraction](./assets/OnDriverDistraction.png)
 |||
 
-
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnKeyboardInput/index.md
+++ b/docs/UI/OnKeyboardInput/index.md
@@ -40,7 +40,9 @@ OnKeyboardInput ENTRY_VOICE mode
 ![OnKeyboardInput](./assets/OnKeyboardInputVoice.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnKeyboardInput/index.md
+++ b/docs/UI/OnKeyboardInput/index.md
@@ -40,7 +40,7 @@ OnKeyboardInput ENTRY_VOICE mode
 ![OnKeyboardInput](./assets/OnKeyboardInputVoice.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnKeyboardInput/index.md
+++ b/docs/UI/OnKeyboardInput/index.md
@@ -40,7 +40,7 @@ OnKeyboardInput ENTRY_VOICE mode
 ![OnKeyboardInput](./assets/OnKeyboardInputVoice.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnLanguageChange/index.md
+++ b/docs/UI/OnLanguageChange/index.md
@@ -23,7 +23,9 @@ OnLanguageChange
 ![OnLanguageChange](./assets/OnLanguageChange.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnLanguageChange/index.md
+++ b/docs/UI/OnLanguageChange/index.md
@@ -23,7 +23,7 @@ OnLanguageChange
 ![OnLanguageChange](./assets/OnLanguageChange.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnLanguageChange/index.md
+++ b/docs/UI/OnLanguageChange/index.md
@@ -23,7 +23,7 @@ OnLanguageChange
 ![OnLanguageChange](./assets/OnLanguageChange.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnRecordStart/index.md
+++ b/docs/UI/OnRecordStart/index.md
@@ -31,7 +31,7 @@ OnRecordStart not sent if UI.PerformAudioPassThru rejected
 ![OnRecordStart](./assets/OnRecordStartRejected.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnRecordStart/index.md
+++ b/docs/UI/OnRecordStart/index.md
@@ -31,7 +31,9 @@ OnRecordStart not sent if UI.PerformAudioPassThru rejected
 ![OnRecordStart](./assets/OnRecordStartRejected.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnRecordStart/index.md
+++ b/docs/UI/OnRecordStart/index.md
@@ -31,7 +31,7 @@ OnRecordStart not sent if UI.PerformAudioPassThru rejected
 ![OnRecordStart](./assets/OnRecordStartRejected.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnResetTimeout/index.md
+++ b/docs/UI/OnResetTimeout/index.md
@@ -32,7 +32,7 @@ OnResetTimeout KEEP_CONTEXT during alert
 ![OnResetTimeout](./assets/OnResetTimeoutKeepContextAlert.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnResetTimeout/index.md
+++ b/docs/UI/OnResetTimeout/index.md
@@ -32,7 +32,7 @@ OnResetTimeout KEEP_CONTEXT during alert
 ![OnResetTimeout](./assets/OnResetTimeoutKeepContextAlert.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnResetTimeout/index.md
+++ b/docs/UI/OnResetTimeout/index.md
@@ -32,7 +32,9 @@ OnResetTimeout KEEP_CONTEXT during alert
 ![OnResetTimeout](./assets/OnResetTimeoutKeepContextAlert.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnSystemContext/index.md
+++ b/docs/UI/OnSystemContext/index.md
@@ -25,7 +25,7 @@ OnSystemContext for different HMI States
 ![OnSystemContext](./assets/OnSystemContext.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnSystemContext/index.md
+++ b/docs/UI/OnSystemContext/index.md
@@ -25,7 +25,9 @@ OnSystemContext for different HMI States
 ![OnSystemContext](./assets/OnSystemContext.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnSystemContext/index.md
+++ b/docs/UI/OnSystemContext/index.md
@@ -25,7 +25,7 @@ OnSystemContext for different HMI States
 ![OnSystemContext](./assets/OnSystemContext.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnTouchEvent/index.md
+++ b/docs/UI/OnTouchEvent/index.md
@@ -29,7 +29,7 @@ OnTouchEvent moving two fingers one stops first
 ![OnTouchEvent](./assets/OnTouchEventTwoFingersOneStop.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnTouchEvent/index.md
+++ b/docs/UI/OnTouchEvent/index.md
@@ -29,7 +29,7 @@ OnTouchEvent moving two fingers one stops first
 ![OnTouchEvent](./assets/OnTouchEventTwoFingersOneStop.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/OnTouchEvent/index.md
+++ b/docs/UI/OnTouchEvent/index.md
@@ -29,7 +29,9 @@ OnTouchEvent moving two fingers one stops first
 ![OnTouchEvent](./assets/OnTouchEventTwoFingersOneStop.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/UI/PerformAudioPassThru/index.md
+++ b/docs/UI/PerformAudioPassThru/index.md
@@ -44,7 +44,7 @@ PerformAudioPassThru from vehicle microphone
 ![PerformAudioPassThru](./assets/PerformAudioPassThruMic.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -62,7 +62,8 @@ PerformAudioPassThru from vehicle microphone
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -76,7 +77,7 @@ PerformAudioPassThru from vehicle microphone
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/PerformAudioPassThru/index.md
+++ b/docs/UI/PerformAudioPassThru/index.md
@@ -44,7 +44,7 @@ PerformAudioPassThru from vehicle microphone
 ![PerformAudioPassThru](./assets/PerformAudioPassThruMic.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -63,7 +63,7 @@ PerformAudioPassThru from vehicle microphone
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -77,7 +77,7 @@ PerformAudioPassThru from vehicle microphone
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/PerformAudioPassThru/index.md
+++ b/docs/UI/PerformAudioPassThru/index.md
@@ -44,7 +44,9 @@ PerformAudioPassThru from vehicle microphone
 ![PerformAudioPassThru](./assets/PerformAudioPassThruMic.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -63,7 +65,7 @@ PerformAudioPassThru from vehicle microphone
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -77,7 +79,7 @@ PerformAudioPassThru from vehicle microphone
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/PerformInteraction/index.md
+++ b/docs/UI/PerformInteraction/index.md
@@ -64,7 +64,9 @@ PerformInteraction Timeout with Both
 ![PerformInteraction](./assets/PerformInteractionBothTimeout.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -137,7 +139,7 @@ PerformInteraction Timeout with Both
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -152,7 +154,7 @@ PerformInteraction Timeout with Both
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/PerformInteraction/index.md
+++ b/docs/UI/PerformInteraction/index.md
@@ -64,7 +64,7 @@ PerformInteraction Timeout with Both
 ![PerformInteraction](./assets/PerformInteractionBothTimeout.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -137,7 +137,7 @@ PerformInteraction Timeout with Both
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -152,7 +152,7 @@ PerformInteraction Timeout with Both
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/PerformInteraction/index.md
+++ b/docs/UI/PerformInteraction/index.md
@@ -64,7 +64,7 @@ PerformInteraction Timeout with Both
 ![PerformInteraction](./assets/PerformInteractionBothTimeout.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -136,7 +136,8 @@ PerformInteraction Timeout with Both
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -151,7 +152,7 @@ PerformInteraction Timeout with Both
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/ScrollableMessage/index.md
+++ b/docs/UI/ScrollableMessage/index.md
@@ -41,7 +41,9 @@ ScrollableMessage with STEAL_FOCUS button for background application
 ![ScrollableMessage](./assets/ScrollableMessageStealFocus.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -73,7 +75,7 @@ ScrollableMessage with STEAL_FOCUS button for background application
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -87,7 +89,7 @@ ScrollableMessage with STEAL_FOCUS button for background application
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/ScrollableMessage/index.md
+++ b/docs/UI/ScrollableMessage/index.md
@@ -41,7 +41,7 @@ ScrollableMessage with STEAL_FOCUS button for background application
 ![ScrollableMessage](./assets/ScrollableMessageStealFocus.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -73,7 +73,7 @@ ScrollableMessage with STEAL_FOCUS button for background application
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -87,7 +87,7 @@ ScrollableMessage with STEAL_FOCUS button for background application
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/ScrollableMessage/index.md
+++ b/docs/UI/ScrollableMessage/index.md
@@ -41,7 +41,7 @@ ScrollableMessage with STEAL_FOCUS button for background application
 ![ScrollableMessage](./assets/ScrollableMessageStealFocus.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -55,7 +55,7 @@ ScrollableMessage with STEAL_FOCUS button for background application
 		},
 		"timeout": 10000,
 		"softButtons": [
-      {
+			{
 				"type": "TEXT",
 				"text": "Leave onscreen",
 				"softButtonID": 15,
@@ -72,7 +72,8 @@ ScrollableMessage with STEAL_FOCUS button for background application
 	}
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -86,7 +87,7 @@ ScrollableMessage with STEAL_FOCUS button for background application
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/SendHapticData/index.md
+++ b/docs/UI/SendHapticData/index.md
@@ -51,7 +51,7 @@ SendHapticData basic flow with user selection
 ![SendHapticData](./assets/SendHapticDataBasicFlow.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -77,7 +77,8 @@ SendHapticData basic flow with user selection
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -91,7 +92,7 @@ SendHapticData basic flow with user selection
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/SendHapticData/index.md
+++ b/docs/UI/SendHapticData/index.md
@@ -51,7 +51,9 @@ SendHapticData basic flow with user selection
 ![SendHapticData](./assets/SendHapticDataBasicFlow.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -78,7 +80,7 @@ SendHapticData basic flow with user selection
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -92,7 +94,7 @@ SendHapticData basic flow with user selection
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/SendHapticData/index.md
+++ b/docs/UI/SendHapticData/index.md
@@ -51,7 +51,7 @@ SendHapticData basic flow with user selection
 ![SendHapticData](./assets/SendHapticDataBasicFlow.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -78,7 +78,7 @@ SendHapticData basic flow with user selection
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -92,7 +92,7 @@ SendHapticData basic flow with user selection
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/SetAppIcon/index.md
+++ b/docs/UI/SetAppIcon/index.md
@@ -37,7 +37,7 @@ SetAppIcon
 ![SetAppIcon](./assets/SetAppIcon.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -56,7 +56,7 @@ SetAppIcon
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -70,7 +70,7 @@ SetAppIcon
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/SetAppIcon/index.md
+++ b/docs/UI/SetAppIcon/index.md
@@ -37,7 +37,9 @@ SetAppIcon
 ![SetAppIcon](./assets/SetAppIcon.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -56,7 +58,7 @@ SetAppIcon
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -70,7 +72,7 @@ SetAppIcon
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/SetAppIcon/index.md
+++ b/docs/UI/SetAppIcon/index.md
@@ -37,7 +37,7 @@ SetAppIcon
 ![SetAppIcon](./assets/SetAppIcon.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -55,7 +55,8 @@ SetAppIcon
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -69,7 +70,7 @@ SetAppIcon
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/SetDisplayLayout/index.md
+++ b/docs/UI/SetDisplayLayout/index.md
@@ -41,7 +41,7 @@ SetDisplayLayout Invalid Data with UI.GetCapabilities
 ![SetDisplayLayout](./assets/SetDisplayLayoutInvalidData.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -55,7 +55,8 @@ SetDisplayLayout Invalid Data with UI.GetCapabilities
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -178,7 +179,7 @@ SetDisplayLayout Invalid Data with UI.GetCapabilities
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/SetDisplayLayout/index.md
+++ b/docs/UI/SetDisplayLayout/index.md
@@ -41,7 +41,7 @@ SetDisplayLayout Invalid Data with UI.GetCapabilities
 ![SetDisplayLayout](./assets/SetDisplayLayoutInvalidData.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -56,7 +56,7 @@ SetDisplayLayout Invalid Data with UI.GetCapabilities
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -179,7 +179,7 @@ SetDisplayLayout Invalid Data with UI.GetCapabilities
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/SetDisplayLayout/index.md
+++ b/docs/UI/SetDisplayLayout/index.md
@@ -41,7 +41,9 @@ SetDisplayLayout Invalid Data with UI.GetCapabilities
 ![SetDisplayLayout](./assets/SetDisplayLayoutInvalidData.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -56,7 +58,7 @@ SetDisplayLayout Invalid Data with UI.GetCapabilities
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -179,7 +181,7 @@ SetDisplayLayout Invalid Data with UI.GetCapabilities
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/SetGlobalProperties/index.md
+++ b/docs/UI/SetGlobalProperties/index.md
@@ -96,7 +96,7 @@ SetGlobalProperties for active app on HMI with VR activation
 ![SetGlobalProperties](./assets/SetGlobalPropertiesActiveVRActivate.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -149,7 +149,8 @@ SetGlobalProperties for active app on HMI with VR activation
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -163,7 +164,7 @@ SetGlobalProperties for active app on HMI with VR activation
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/SetGlobalProperties/index.md
+++ b/docs/UI/SetGlobalProperties/index.md
@@ -96,7 +96,7 @@ SetGlobalProperties for active app on HMI with VR activation
 ![SetGlobalProperties](./assets/SetGlobalPropertiesActiveVRActivate.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -150,7 +150,7 @@ SetGlobalProperties for active app on HMI with VR activation
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -164,7 +164,7 @@ SetGlobalProperties for active app on HMI with VR activation
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/SetGlobalProperties/index.md
+++ b/docs/UI/SetGlobalProperties/index.md
@@ -96,7 +96,9 @@ SetGlobalProperties for active app on HMI with VR activation
 ![SetGlobalProperties](./assets/SetGlobalPropertiesActiveVRActivate.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -150,7 +152,7 @@ SetGlobalProperties for active app on HMI with VR activation
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -164,7 +166,7 @@ SetGlobalProperties for active app on HMI with VR activation
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/SetMediaClockTimer/index.md
+++ b/docs/UI/SetMediaClockTimer/index.md
@@ -70,7 +70,7 @@ SetMediaClockTimer COUNTDOWN for a deactivated application
 ![SetMediaClockTimer](./assets/SetMediaClockTimerDownDeactivate.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -92,7 +92,7 @@ SetMediaClockTimer COUNTDOWN for a deactivated application
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -106,7 +106,7 @@ SetMediaClockTimer COUNTDOWN for a deactivated application
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/SetMediaClockTimer/index.md
+++ b/docs/UI/SetMediaClockTimer/index.md
@@ -11,7 +11,7 @@ Purpose
 
 The UI.SetMediaClock timer request indicates either an initial value for the media clock timer for a media application or an update to this value. The request may come for the application which is not currently active on the HMI.
 
-### Request   
+### Request
 
 !!! MUST
 1. Perform the update type indicated by the `updateMode` parameter:   
@@ -70,7 +70,7 @@ SetMediaClockTimer COUNTDOWN for a deactivated application
 ![SetMediaClockTimer](./assets/SetMediaClockTimerDownDeactivate.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -91,7 +91,8 @@ SetMediaClockTimer COUNTDOWN for a deactivated application
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -105,7 +106,7 @@ SetMediaClockTimer COUNTDOWN for a deactivated application
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/SetMediaClockTimer/index.md
+++ b/docs/UI/SetMediaClockTimer/index.md
@@ -70,7 +70,9 @@ SetMediaClockTimer COUNTDOWN for a deactivated application
 ![SetMediaClockTimer](./assets/SetMediaClockTimerDownDeactivate.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -92,7 +94,7 @@ SetMediaClockTimer COUNTDOWN for a deactivated application
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -106,7 +108,7 @@ SetMediaClockTimer COUNTDOWN for a deactivated application
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/Show/index.md
+++ b/docs/UI/Show/index.md
@@ -53,7 +53,7 @@ Show Widgets
 ![Show](./assets/ShowWidgets.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -109,7 +109,7 @@ Show Widgets
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -123,7 +123,7 @@ Show Widgets
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/Show/index.md
+++ b/docs/UI/Show/index.md
@@ -53,7 +53,7 @@ Show Widgets
 ![Show](./assets/ShowWidgets.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -108,7 +108,8 @@ Show Widgets
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -122,7 +123,7 @@ Show Widgets
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/UI/Show/index.md
+++ b/docs/UI/Show/index.md
@@ -53,7 +53,9 @@ Show Widgets
 ![Show](./assets/ShowWidgets.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -109,7 +111,7 @@ Show Widgets
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -123,7 +125,7 @@ Show Widgets
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/ShowAppMenu/index.md
+++ b/docs/UI/ShowAppMenu/index.md
@@ -39,7 +39,7 @@ ShowAppMenu request(with menuID)
 ![ShowAppMenuwithMenuID](./assets/ShowAppMenu_MenuID.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -54,7 +54,7 @@ ShowAppMenu request(with menuID)
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -68,7 +68,7 @@ ShowAppMenu request(with menuID)
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/ShowAppMenu/index.md
+++ b/docs/UI/ShowAppMenu/index.md
@@ -39,7 +39,7 @@ ShowAppMenu request(with menuID)
 ![ShowAppMenuwithMenuID](./assets/ShowAppMenu_MenuID.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -53,7 +53,8 @@ ShowAppMenu request(with menuID)
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -63,6 +64,24 @@ ShowAppMenu request(with menuID)
   {
     "code" : 0,
     "method" : "UI.ShowAppMenu"
+  }
+}
+```
+
+### JSON Example Error
+
+```json
+{
+  "id" : 176,
+  "jsonrpc" : "2.0",
+  "error" :
+  {
+    "code" : 22,
+    "message" : "Request timeout",
+    "data" :
+    {
+      "method" : "UI.ShowAppMenu"
+    }
   }
 }
 ```

--- a/docs/UI/ShowAppMenu/index.md
+++ b/docs/UI/ShowAppMenu/index.md
@@ -39,7 +39,9 @@ ShowAppMenu request(with menuID)
 ![ShowAppMenuwithMenuID](./assets/ShowAppMenu_MenuID.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -54,7 +56,7 @@ ShowAppMenu request(with menuID)
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -68,7 +70,7 @@ ShowAppMenu request(with menuID)
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/Slider/index.md
+++ b/docs/UI/Slider/index.md
@@ -45,7 +45,9 @@ Slider with OK Button press
 ![Slider](./assets/SliderOK.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -64,7 +66,7 @@ Slider with OK Button press
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -79,7 +81,7 @@ Slider with OK Button press
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/UI/Slider/index.md
+++ b/docs/UI/Slider/index.md
@@ -45,7 +45,7 @@ Slider with OK Button press
 ![Slider](./assets/SliderOK.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -64,7 +64,7 @@ Slider with OK Button press
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -79,7 +79,7 @@ Slider with OK Button press
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/UI/Slider/index.md
+++ b/docs/UI/Slider/index.md
@@ -45,7 +45,7 @@ Slider with OK Button press
 ![Slider](./assets/SliderOK.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -63,7 +63,8 @@ Slider with OK Button press
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -78,7 +79,7 @@ Slider with OK Button press
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VR/AddCommand/index.md
+++ b/docs/VR/AddCommand/index.md
@@ -56,7 +56,7 @@ UI.AddCommand no response, VR.AddCommand returns SUCCESS
 ![AddCommand](./assets/AddCommandSuccessUINoResponse.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -78,7 +78,7 @@ UI.AddCommand no response, VR.AddCommand returns SUCCESS
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -92,7 +92,7 @@ UI.AddCommand no response, VR.AddCommand returns SUCCESS
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VR/AddCommand/index.md
+++ b/docs/VR/AddCommand/index.md
@@ -56,7 +56,9 @@ UI.AddCommand no response, VR.AddCommand returns SUCCESS
 ![AddCommand](./assets/AddCommandSuccessUINoResponse.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -78,7 +80,7 @@ UI.AddCommand no response, VR.AddCommand returns SUCCESS
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -92,7 +94,7 @@ UI.AddCommand no response, VR.AddCommand returns SUCCESS
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VR/AddCommand/index.md
+++ b/docs/VR/AddCommand/index.md
@@ -56,7 +56,7 @@ UI.AddCommand no response, VR.AddCommand returns SUCCESS
 ![AddCommand](./assets/AddCommandSuccessUINoResponse.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -77,7 +77,8 @@ UI.AddCommand no response, VR.AddCommand returns SUCCESS
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -91,7 +92,7 @@ UI.AddCommand no response, VR.AddCommand returns SUCCESS
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VR/ChangeRegistration/index.md
+++ b/docs/VR/ChangeRegistration/index.md
@@ -31,7 +31,7 @@ ChangeRegistration
 ![ChangeRegistration](./assets/ChangeRegistration.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -46,7 +46,7 @@ ChangeRegistration
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -60,7 +60,7 @@ ChangeRegistration
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VR/ChangeRegistration/index.md
+++ b/docs/VR/ChangeRegistration/index.md
@@ -31,7 +31,7 @@ ChangeRegistration
 ![ChangeRegistration](./assets/ChangeRegistration.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -45,7 +45,8 @@ ChangeRegistration
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -59,7 +60,7 @@ ChangeRegistration
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VR/ChangeRegistration/index.md
+++ b/docs/VR/ChangeRegistration/index.md
@@ -31,7 +31,9 @@ ChangeRegistration
 ![ChangeRegistration](./assets/ChangeRegistration.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -46,7 +48,7 @@ ChangeRegistration
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -60,7 +62,7 @@ ChangeRegistration
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VR/DeleteCommand/index.md
+++ b/docs/VR/DeleteCommand/index.md
@@ -32,7 +32,9 @@ DeleteCommand
 ![DeleteCommand](./assets/DeleteCommand.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -49,7 +51,7 @@ DeleteCommand
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -63,7 +65,7 @@ DeleteCommand
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VR/DeleteCommand/index.md
+++ b/docs/VR/DeleteCommand/index.md
@@ -32,7 +32,7 @@ DeleteCommand
 ![DeleteCommand](./assets/DeleteCommand.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -48,7 +48,8 @@ DeleteCommand
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -62,7 +63,7 @@ DeleteCommand
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VR/DeleteCommand/index.md
+++ b/docs/VR/DeleteCommand/index.md
@@ -32,7 +32,7 @@ DeleteCommand
 ![DeleteCommand](./assets/DeleteCommand.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -49,7 +49,7 @@ DeleteCommand
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -63,7 +63,7 @@ DeleteCommand
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VR/GetCapabilities/index.md
+++ b/docs/VR/GetCapabilities/index.md
@@ -23,7 +23,7 @@ This RPC has no additional parameter requirements
 |:---|:---|:--------|:---------|
 |vrCapabilities|[Common.VrCapabilities](../../common/enums/#vrcapabilities)|false|array: true<br>minsize: 1<br>maxsize: 100|
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -32,7 +32,8 @@ This RPC has no additional parameter requirements
   "method" : "VR.GetCapabilities"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -47,7 +48,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VR/GetCapabilities/index.md
+++ b/docs/VR/GetCapabilities/index.md
@@ -23,7 +23,7 @@ This RPC has no additional parameter requirements
 |:---|:---|:--------|:---------|
 |vrCapabilities|[Common.VrCapabilities](../../common/enums/#vrcapabilities)|false|array: true<br>minsize: 1<br>maxsize: 100|
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -33,7 +33,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -48,7 +48,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VR/GetCapabilities/index.md
+++ b/docs/VR/GetCapabilities/index.md
@@ -23,6 +23,12 @@ This RPC has no additional parameter requirements
 |:---|:---|:--------|:---------|
 |vrCapabilities|[Common.VrCapabilities](../../common/enums/#vrcapabilities)|false|array: true<br>minsize: 1<br>maxsize: 100|
 
+### Sequence Diagrams
+|||
+GetCapabilities
+![GetCapabilities](./assets/GetCapabilities.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Request
@@ -67,9 +73,3 @@ This RPC has no additional parameter requirements
   }
 }
 ```
-
-### Sequence Diagrams
-|||
-GetCapabilities
-![GetCapabilities](./assets/GetCapabilities.png)
-|||

--- a/docs/VR/GetCapabilities/index.md
+++ b/docs/VR/GetCapabilities/index.md
@@ -23,7 +23,9 @@ This RPC has no additional parameter requirements
 |:---|:---|:--------|:---------|
 |vrCapabilities|[Common.VrCapabilities](../../common/enums/#vrcapabilities)|false|array: true<br>minsize: 1<br>maxsize: 100|
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -33,7 +35,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -48,7 +50,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VR/GetLanguage/index.md
+++ b/docs/VR/GetLanguage/index.md
@@ -29,7 +29,7 @@ GetLanguage
 ![GetLanguage](./assets/GetLanguage.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -38,7 +38,8 @@ GetLanguage
   "method" : "VR.GetLanguage"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -53,7 +54,7 @@ GetLanguage
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VR/GetLanguage/index.md
+++ b/docs/VR/GetLanguage/index.md
@@ -29,7 +29,7 @@ GetLanguage
 ![GetLanguage](./assets/GetLanguage.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -39,7 +39,7 @@ GetLanguage
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -54,7 +54,7 @@ GetLanguage
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VR/GetLanguage/index.md
+++ b/docs/VR/GetLanguage/index.md
@@ -29,7 +29,9 @@ GetLanguage
 ![GetLanguage](./assets/GetLanguage.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -39,7 +41,7 @@ GetLanguage
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -54,7 +56,7 @@ GetLanguage
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VR/GetSupportedLanguages/index.md
+++ b/docs/VR/GetSupportedLanguages/index.md
@@ -23,7 +23,9 @@ This RPC has no additional parameter requirements
 |:---|:---|:--------|:---------|
 |languages|[Common.Language](../../common/enums/#language)|true|array: true<br>minsize: 1<br>maxsize: 100|
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -33,7 +35,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -48,7 +50,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VR/GetSupportedLanguages/index.md
+++ b/docs/VR/GetSupportedLanguages/index.md
@@ -23,6 +23,12 @@ This RPC has no additional parameter requirements
 |:---|:---|:--------|:---------|
 |languages|[Common.Language](../../common/enums/#language)|true|array: true<br>minsize: 1<br>maxsize: 100|
 
+### Sequence Diagrams
+|||
+GetSupportedLanguages
+![GetSupportedLanguages](./assets/GetSupportedLanguages.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Request
@@ -67,9 +73,3 @@ This RPC has no additional parameter requirements
   }
 }
 ```
-
-### Sequence Diagrams
-|||
-GetSupportedLanguages
-![GetSupportedLanguages](./assets/GetSupportedLanguages.png)
-|||

--- a/docs/VR/GetSupportedLanguages/index.md
+++ b/docs/VR/GetSupportedLanguages/index.md
@@ -23,7 +23,7 @@ This RPC has no additional parameter requirements
 |:---|:---|:--------|:---------|
 |languages|[Common.Language](../../common/enums/#language)|true|array: true<br>minsize: 1<br>maxsize: 100|
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -32,7 +32,8 @@ This RPC has no additional parameter requirements
   "method" : "VR.GetSupportedLanguages"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -47,7 +48,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VR/GetSupportedLanguages/index.md
+++ b/docs/VR/GetSupportedLanguages/index.md
@@ -23,7 +23,7 @@ This RPC has no additional parameter requirements
 |:---|:---|:--------|:---------|
 |languages|[Common.Language](../../common/enums/#language)|true|array: true<br>minsize: 1<br>maxsize: 100|
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -33,7 +33,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -48,7 +48,7 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VR/IsReady/index.md
+++ b/docs/VR/IsReady/index.md
@@ -44,7 +44,9 @@ IsReady
 ![IsReady](./assets/IsReady.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -54,7 +56,7 @@ IsReady
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -69,7 +71,7 @@ IsReady
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VR/IsReady/index.md
+++ b/docs/VR/IsReady/index.md
@@ -44,7 +44,7 @@ IsReady
 ![IsReady](./assets/IsReady.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -54,7 +54,7 @@ IsReady
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -69,7 +69,7 @@ IsReady
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VR/IsReady/index.md
+++ b/docs/VR/IsReady/index.md
@@ -44,7 +44,7 @@ IsReady
 ![IsReady](./assets/IsReady.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -53,7 +53,8 @@ IsReady
   "method" : "VR.IsReady"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -68,7 +69,7 @@ IsReady
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VR/OnCommand/index.md
+++ b/docs/VR/OnCommand/index.md
@@ -24,7 +24,7 @@ OnCommand
 ![OnCommand](./assets/OnCommand.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/VR/OnCommand/index.md
+++ b/docs/VR/OnCommand/index.md
@@ -24,7 +24,9 @@ OnCommand
 ![OnCommand](./assets/OnCommand.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/VR/OnCommand/index.md
+++ b/docs/VR/OnCommand/index.md
@@ -24,7 +24,7 @@ OnCommand
 ![OnCommand](./assets/OnCommand.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/VR/OnLanguageChange/index.md
+++ b/docs/VR/OnLanguageChange/index.md
@@ -23,7 +23,9 @@ OnLanguageChange
 ![OnLanguageChange](./assets/OnLanguageChange.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/VR/OnLanguageChange/index.md
+++ b/docs/VR/OnLanguageChange/index.md
@@ -23,7 +23,7 @@ OnLanguageChange
 ![OnLanguageChange](./assets/OnLanguageChange.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/VR/OnLanguageChange/index.md
+++ b/docs/VR/OnLanguageChange/index.md
@@ -23,7 +23,7 @@ OnLanguageChange
 ![OnLanguageChange](./assets/OnLanguageChange.png)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/VR/PerformInteraction/index.md
+++ b/docs/VR/PerformInteraction/index.md
@@ -45,7 +45,9 @@ PerformInteraction in Both Mode times out
 ![PerformInteraction](./assets/PerformInteractionBothTimeout.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -93,7 +95,7 @@ PerformInteraction in Both Mode times out
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -108,7 +110,7 @@ PerformInteraction in Both Mode times out
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VR/PerformInteraction/index.md
+++ b/docs/VR/PerformInteraction/index.md
@@ -45,7 +45,7 @@ PerformInteraction in Both Mode times out
 ![PerformInteraction](./assets/PerformInteractionBothTimeout.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -92,7 +92,8 @@ PerformInteraction in Both Mode times out
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -107,7 +108,7 @@ PerformInteraction in Both Mode times out
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VR/PerformInteraction/index.md
+++ b/docs/VR/PerformInteraction/index.md
@@ -45,7 +45,7 @@ PerformInteraction in Both Mode times out
 ![PerformInteraction](./assets/PerformInteractionBothTimeout.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -93,7 +93,7 @@ PerformInteraction in Both Mode times out
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -108,7 +108,7 @@ PerformInteraction in Both Mode times out
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VR/Started/index.md
+++ b/docs/VR/Started/index.md
@@ -15,7 +15,7 @@ Purpose
 
 This RPC has no additional parameter requirements
 
-### JSON Example Notification
+### Example Notification
 
 ```json
 {

--- a/docs/VR/Started/index.md
+++ b/docs/VR/Started/index.md
@@ -31,4 +31,3 @@ Started on PTT Button Press
   "method" : "VR.Started"
 }
 ```
-

--- a/docs/VR/Started/index.md
+++ b/docs/VR/Started/index.md
@@ -15,7 +15,7 @@ Purpose
 
 This RPC has no additional parameter requirements
 
-#### JSON Example Notification
+### JSON Example Notification
 
 ```json
 {

--- a/docs/VR/Started/index.md
+++ b/docs/VR/Started/index.md
@@ -15,7 +15,9 @@ Purpose
 
 This RPC has no additional parameter requirements
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 
 ```json
 {

--- a/docs/VR/Started/index.md
+++ b/docs/VR/Started/index.md
@@ -15,6 +15,12 @@ Purpose
 
 This RPC has no additional parameter requirements
 
+### Sequence Diagrams
+|||
+Started on PTT Button Press
+![Started](./assets/Started.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Notification
@@ -26,8 +32,3 @@ This RPC has no additional parameter requirements
 }
 ```
 
-### Sequence Diagrams
-|||
-Started on PTT Button Press
-![Started](./assets/Started.png)
-|||

--- a/docs/VR/Stopped/index.md
+++ b/docs/VR/Stopped/index.md
@@ -21,7 +21,7 @@ Stopped when VR session ends
 ![Stopped](./assets/Stopped.png)
 |||
 
-### JSON Example Notification
+### Example Notification
 
 ```json
 {

--- a/docs/VR/Stopped/index.md
+++ b/docs/VR/Stopped/index.md
@@ -21,7 +21,7 @@ Stopped when VR session ends
 ![Stopped](./assets/Stopped.png)
 |||
 
-### Example Notification
+### JSON Example Notification
 
 ```json
 {

--- a/docs/VR/Stopped/index.md
+++ b/docs/VR/Stopped/index.md
@@ -21,7 +21,9 @@ Stopped when VR session ends
 ![Stopped](./assets/Stopped.png)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 
 ```json
 {

--- a/docs/VehicleInfo/DiagnosticMessage/index.md
+++ b/docs/VehicleInfo/DiagnosticMessage/index.md
@@ -28,7 +28,7 @@ Purpose
 |:---|:---|:--------|:---------|
 |messageDataResult|Integer|true|array: true<br>minsize: 1<br>maxsize: 65535<br>minvalue: 0<br>maxvalue: 255|
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -43,7 +43,8 @@ Purpose
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -58,7 +59,7 @@ Purpose
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/DiagnosticMessage/index.md
+++ b/docs/VehicleInfo/DiagnosticMessage/index.md
@@ -28,6 +28,12 @@ Purpose
 |:---|:---|:--------|:---------|
 |messageDataResult|Integer|true|array: true<br>minsize: 1<br>maxsize: 65535<br>minvalue: 0<br>maxvalue: 255|
 
+### Sequence Diagrams
+|||
+DiagnosticMessage
+![DiagnosticMessage](./assets/DiagnosticMessage.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Request
@@ -78,9 +84,3 @@ Purpose
   }
 }
 ```
-
-### Sequence Diagrams
-|||
-DiagnosticMessage
-![DiagnosticMessage](./assets/DiagnosticMessage.png)
-|||

--- a/docs/VehicleInfo/DiagnosticMessage/index.md
+++ b/docs/VehicleInfo/DiagnosticMessage/index.md
@@ -28,7 +28,9 @@ Purpose
 |:---|:---|:--------|:---------|
 |messageDataResult|Integer|true|array: true<br>minsize: 1<br>maxsize: 65535<br>minvalue: 0<br>maxvalue: 255|
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -44,7 +46,7 @@ Purpose
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -59,7 +61,7 @@ Purpose
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/DiagnosticMessage/index.md
+++ b/docs/VehicleInfo/DiagnosticMessage/index.md
@@ -28,7 +28,7 @@ Purpose
 |:---|:---|:--------|:---------|
 |messageDataResult|Integer|true|array: true<br>minsize: 1<br>maxsize: 65535<br>minvalue: 0<br>maxvalue: 255|
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -44,7 +44,7 @@ Purpose
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -59,7 +59,7 @@ Purpose
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/GetDTCs/index.md
+++ b/docs/VehicleInfo/GetDTCs/index.md
@@ -28,7 +28,9 @@ Purpose
 |ecuHeader|Integer|true|minvalue: 0<br>maxvalue: 65535|
 |dtc|String|false|array: true<br>minsize: 1<br>maxsize: 15<br>maxlength: 10|
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -44,7 +46,7 @@ Purpose
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -60,7 +62,7 @@ Purpose
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/GetDTCs/index.md
+++ b/docs/VehicleInfo/GetDTCs/index.md
@@ -28,6 +28,12 @@ Purpose
 |ecuHeader|Integer|true|minvalue: 0<br>maxvalue: 65535|
 |dtc|String|false|array: true<br>minsize: 1<br>maxsize: 15<br>maxlength: 10|
 
+### Sequence Diagrams
+|||
+GetDTCs
+![GetDTCs](./assets/GetDTCs.png)
+|||
+
 ### JSON Message Examples
 
 #### Example Request
@@ -79,9 +85,3 @@ Purpose
   }
 }
 ```
-
-### Sequence Diagrams
-|||
-GetDTCs
-![GetDTCs](./assets/GetDTCs.png)
-|||

--- a/docs/VehicleInfo/GetDTCs/index.md
+++ b/docs/VehicleInfo/GetDTCs/index.md
@@ -28,7 +28,7 @@ Purpose
 |ecuHeader|Integer|true|minvalue: 0<br>maxvalue: 65535|
 |dtc|String|false|array: true<br>minsize: 1<br>maxsize: 15<br>maxlength: 10|
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -44,7 +44,7 @@ Purpose
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -60,7 +60,7 @@ Purpose
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/GetDTCs/index.md
+++ b/docs/VehicleInfo/GetDTCs/index.md
@@ -28,7 +28,7 @@ Purpose
 |ecuHeader|Integer|true|minvalue: 0<br>maxvalue: 65535|
 |dtc|String|false|array: true<br>minsize: 1<br>maxsize: 15<br>maxlength: 10|
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -43,7 +43,8 @@ Purpose
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -59,7 +60,7 @@ Purpose
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/GetVehicleData/index.md
+++ b/docs/VehicleInfo/GetVehicleData/index.md
@@ -120,7 +120,7 @@ GetVehicleData with custom data
 ![CustomVehicleData](./assets/GVD_custom_data.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -145,7 +145,8 @@ GetVehicleData with custom data
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -233,7 +234,7 @@ GetVehicleData with custom data
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/GetVehicleData/index.md
+++ b/docs/VehicleInfo/GetVehicleData/index.md
@@ -120,7 +120,9 @@ GetVehicleData with custom data
 ![CustomVehicleData](./assets/GVD_custom_data.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -146,7 +148,7 @@ GetVehicleData with custom data
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -234,7 +236,7 @@ GetVehicleData with custom data
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/GetVehicleData/index.md
+++ b/docs/VehicleInfo/GetVehicleData/index.md
@@ -120,7 +120,7 @@ GetVehicleData with custom data
 ![CustomVehicleData](./assets/GVD_custom_data.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -146,7 +146,7 @@ GetVehicleData with custom data
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -234,7 +234,7 @@ GetVehicleData with custom data
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/GetVehicleType/index.md
+++ b/docs/VehicleInfo/GetVehicleType/index.md
@@ -29,7 +29,7 @@ GetVehicleType
 ![GetVehicleType](./assets/GetVehicleType.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -38,7 +38,8 @@ GetVehicleType
   "method" : "VehicleInfo.GetVehicleType"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -58,7 +59,7 @@ GetVehicleType
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/GetVehicleType/index.md
+++ b/docs/VehicleInfo/GetVehicleType/index.md
@@ -29,7 +29,7 @@ GetVehicleType
 ![GetVehicleType](./assets/GetVehicleType.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -39,7 +39,7 @@ GetVehicleType
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -59,7 +59,7 @@ GetVehicleType
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/GetVehicleType/index.md
+++ b/docs/VehicleInfo/GetVehicleType/index.md
@@ -29,7 +29,9 @@ GetVehicleType
 ![GetVehicleType](./assets/GetVehicleType.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -39,7 +41,7 @@ GetVehicleType
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -59,7 +61,7 @@ GetVehicleType
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/IsReady/index.md
+++ b/docs/VehicleInfo/IsReady/index.md
@@ -44,7 +44,9 @@ IsReady
 ![IsReady](./assets/IsReady.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -54,7 +56,7 @@ IsReady
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -69,7 +71,7 @@ IsReady
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/IsReady/index.md
+++ b/docs/VehicleInfo/IsReady/index.md
@@ -44,7 +44,7 @@ IsReady
 ![IsReady](./assets/IsReady.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -54,7 +54,7 @@ IsReady
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -69,7 +69,7 @@ IsReady
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/IsReady/index.md
+++ b/docs/VehicleInfo/IsReady/index.md
@@ -44,7 +44,7 @@ IsReady
 ![IsReady](./assets/IsReady.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -53,7 +53,8 @@ IsReady
   "method" : "VehicleInfo.IsReady"
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -68,7 +69,7 @@ IsReady
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/OnVehicleData/index.md
+++ b/docs/VehicleInfo/OnVehicleData/index.md
@@ -68,7 +68,9 @@ OnVehicleData
 ![OnVehicleData](./assets/OnVehicleData.jpg)
 |||
 
-### Example Notification
+### JSON Message Examples
+
+#### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/VehicleInfo/OnVehicleData/index.md
+++ b/docs/VehicleInfo/OnVehicleData/index.md
@@ -68,7 +68,7 @@ OnVehicleData
 ![OnVehicleData](./assets/OnVehicleData.jpg)
 |||
 
-### JSON Example Notification
+### Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/VehicleInfo/OnVehicleData/index.md
+++ b/docs/VehicleInfo/OnVehicleData/index.md
@@ -68,7 +68,7 @@ OnVehicleData
 ![OnVehicleData](./assets/OnVehicleData.jpg)
 |||
 
-#### JSON Example Notification
+### JSON Example Notification
 ```json
 {
   "jsonrpc" : "2.0",

--- a/docs/VehicleInfo/ReadDID/index.md
+++ b/docs/VehicleInfo/ReadDID/index.md
@@ -37,7 +37,9 @@ ReadDID Expanded result
 ![ReadDID](./assets/ReadDidExpanded.png)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -53,7 +55,7 @@ ReadDID Expanded result
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -84,7 +86,7 @@ ReadDID Expanded result
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/ReadDID/index.md
+++ b/docs/VehicleInfo/ReadDID/index.md
@@ -37,7 +37,7 @@ ReadDID Expanded result
 ![ReadDID](./assets/ReadDidExpanded.png)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -52,7 +52,8 @@ ReadDID Expanded result
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -83,7 +84,7 @@ ReadDID Expanded result
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/ReadDID/index.md
+++ b/docs/VehicleInfo/ReadDID/index.md
@@ -37,7 +37,7 @@ ReadDID Expanded result
 ![ReadDID](./assets/ReadDidExpanded.png)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -53,7 +53,7 @@ ReadDID Expanded result
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -84,7 +84,7 @@ ReadDID Expanded result
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/SubscribeVehicleData/index.md
+++ b/docs/VehicleInfo/SubscribeVehicleData/index.md
@@ -99,7 +99,7 @@ SubscribeVehicleData
 ![SubscribeVehicleData](./assets/SubscribeVehicleData.jpg)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -125,7 +125,7 @@ SubscribeVehicleData
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -217,7 +217,7 @@ SubscribeVehicleData
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/SubscribeVehicleData/index.md
+++ b/docs/VehicleInfo/SubscribeVehicleData/index.md
@@ -99,7 +99,9 @@ SubscribeVehicleData
 ![SubscribeVehicleData](./assets/SubscribeVehicleData.jpg)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -125,7 +127,7 @@ SubscribeVehicleData
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -217,7 +219,7 @@ SubscribeVehicleData
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/SubscribeVehicleData/index.md
+++ b/docs/VehicleInfo/SubscribeVehicleData/index.md
@@ -99,7 +99,7 @@ SubscribeVehicleData
 ![SubscribeVehicleData](./assets/SubscribeVehicleData.jpg)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -124,7 +124,8 @@ SubscribeVehicleData
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -216,7 +217,7 @@ SubscribeVehicleData
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/UnsubscribeVehicleData/index.md
+++ b/docs/VehicleInfo/UnsubscribeVehicleData/index.md
@@ -103,7 +103,7 @@ UnsubscribeVehicleData unexpected disconnect
 ![UnsubscribeVehicleData](./assets/UnsubscribeVehicleDataDisconnect.jpg)
 |||
 
-### Example Request
+### JSON Example Request
 
 ```json
 {
@@ -128,7 +128,8 @@ UnsubscribeVehicleData unexpected disconnect
   }
 }
 ```
-### Example Response
+
+### JSON Example Response
 
 ```json
 {
@@ -220,7 +221,7 @@ UnsubscribeVehicleData unexpected disconnect
 }
 ```
 
-### Example Error
+### JSON Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/UnsubscribeVehicleData/index.md
+++ b/docs/VehicleInfo/UnsubscribeVehicleData/index.md
@@ -103,7 +103,9 @@ UnsubscribeVehicleData unexpected disconnect
 ![UnsubscribeVehicleData](./assets/UnsubscribeVehicleDataDisconnect.jpg)
 |||
 
-### Example Request
+### JSON Message Examples
+
+#### Example Request
 
 ```json
 {
@@ -129,7 +131,7 @@ UnsubscribeVehicleData unexpected disconnect
 }
 ```
 
-### Example Response
+#### Example Response
 
 ```json
 {
@@ -221,7 +223,7 @@ UnsubscribeVehicleData unexpected disconnect
 }
 ```
 
-### Example Error
+#### Example Error
 
 ```json
 {

--- a/docs/VehicleInfo/UnsubscribeVehicleData/index.md
+++ b/docs/VehicleInfo/UnsubscribeVehicleData/index.md
@@ -103,7 +103,7 @@ UnsubscribeVehicleData unexpected disconnect
 ![UnsubscribeVehicleData](./assets/UnsubscribeVehicleDataDisconnect.jpg)
 |||
 
-### JSON Example Request
+### Example Request
 
 ```json
 {
@@ -129,7 +129,7 @@ UnsubscribeVehicleData unexpected disconnect
 }
 ```
 
-### JSON Example Response
+### Example Response
 
 ```json
 {
@@ -221,7 +221,7 @@ UnsubscribeVehicleData unexpected disconnect
 }
 ```
 
-### JSON Example Error
+### Example Error
 
 ```json
 {

--- a/docs/WebSocket Transport/index.md
+++ b/docs/WebSocket Transport/index.md
@@ -101,7 +101,9 @@ An RPC call is represented by sending a Request object to a Server. The Request 
 | "method" | A String containing the information of the method to be invoked. The format is `[componentName].[methodName]`.|
 | "params" | A structured value that holds the parameter values to be used during the invocation of the method. This property may be omitted.|
 
-### Example Requests
+### JSON Message Examples
+
+#### Example Requests
 #### Request with No Parameters
 ```json
 {
@@ -146,7 +148,9 @@ A notification is a request object without an `id` property. For all the other p
 
 The receiver should not reply to a notification, i.e. no response object needs to be returned to the client upon receipt of a notification.
 
-### Example Notifications
+### JSON Message Examples
+
+#### Example Notifications
 #### Notification With No Parameters
 ```json
 {
@@ -183,7 +187,7 @@ On receipt of a request message, the server must reply with a response. The resp
 |"jsonrpc"| Must be exactly **"2.0"**|
 |"result"| Required on Success. Must not exist if there was an error invoking the method. The result property must contain a `method` field which is the same as the corresponding request, a `code` field with **0** to indicate success or **21** to indicate success with warnings.  No other [result codes](../common/enums/#result) should be sent in the result property. The result property may also include additional properties as defined in the HMI_API.|
 
-### Example Responses
+#### Example Responses
 #### Response with No Parameters
 ```json
 {


### PR DESCRIPTION
Currently the documentation has no defined convention for how the sections should be named(For example `#### JSON Example Notification` in some docs and `### Example Notification` in others)