### PR TITLE
[SDL 0253] Feature/New vehicle data `StabilityControlsStatus`

### DIFF
--- a/docs/Common/Enums/index.md
+++ b/docs/Common/Enums/index.md
@@ -889,6 +889,7 @@
 |VEHICLEDATA_ELECTRONICPARKBRAKESTATUS|29||
 |VEHICLEDATA_CLOUDAPPVEHICLEID|30| Parameter used by cloud apps or the policy server to identify a head unit|
 |VEHICLEDATA_OEM_CUSTOM_DATA|31||
+|VEHICLEDATA_STABILITYCONTROLSSTATUS|32||
 
 ### VideoStreamingProtocol
 

--- a/docs/Common/Structs/index.md
+++ b/docs/Common/Structs/index.md
@@ -1130,3 +1130,11 @@ There are no defined parameters for this struct
 |hybridAppPreference|[Common.HybridAppPreference](../enums/#hybridapppreference)|false||Specifies the user preference to use one specific app type or all available types|
 |endpoint|String|false|maxlength: 65535|If specified, which Core uses a client implementation of the connection type and attempts to connect to the endpoint when this app is selected (activated).<br>If omitted, Core won't attempt to connect as the app selection (activation) is managed outside of Core. Instead it uses a server implementation of the connection type and expects the app to connect|
 
+### StabilityControlsStatus
+
+|Name|Type|Mandatory|Additional|Description|
+|:---|:---|:--------|:---------|:----------|
+|escSystem|[Common.VehicleDataStatus](../enums/#vehicledatastatus)|false||true if vehicle stability control is ON,<br>else false|
+|trailerSwayControl|[Common.VehicleDataStatus](../enums/#vehicledatastatus)|false||true if vehicle trailer sway control is ON,<br>else false|
+
+

--- a/docs/VehicleInfo/GetVehicleData/index.md
+++ b/docs/VehicleInfo/GetVehicleData/index.md
@@ -70,6 +70,7 @@ The HMI will have to update this field if the user chooses to reset this value (
 |engineOilLife|Boolean|false||
 |electronicParkBrakeStatus|Boolean|false||
 |cloudAppVehicleID|Boolean|false||
+|stabilityControlsStatus|Boolean|false||
 
 ### Response
 
@@ -107,6 +108,7 @@ The HMI will have to update this field if the user chooses to reset this value (
 |engineOilLife|Float|false|minvalue: 0<br>maxvalue: 100|
 |electronicParkBrakeStatus|[Common.ElectronicParkBrakeStatus](../../common/enums/#electronicparkbrakestatus)|false||
 |cloudAppVehicleID|String|false||
+|stabilityControlsStatus|[Common.StabilityControlsStatus](../../common/structs/#stabilitycontrolsstatus)|false||
 
 ### Sequence Diagrams
 

--- a/docs/VehicleInfo/OnVehicleData/index.md
+++ b/docs/VehicleInfo/OnVehicleData/index.md
@@ -63,6 +63,7 @@ The HMI will have to update this field if the user chooses to reset this value (
 |engineOilLife|Float|false|minvalue: 0<br>maxvalue: 100|
 |electronicParkBrakeStatus|[Common.ElectronicParkBrakeStatus](../../common/enums/#electronicparkbrakestatus)|false||
 |cloudAppVehicleID|String|false||
+|stabilityControlsStatus|[Common.StabilityControlsStatus](../../common/structs/#stabilitycontrolsstatus)|false||
 
 ### Sequence Diagrams
 

--- a/docs/VehicleInfo/SubscribeVehicleData/index.md
+++ b/docs/VehicleInfo/SubscribeVehicleData/index.md
@@ -44,6 +44,7 @@ Purpose
 |engineOilLife|Boolean|false||
 |electronicParkBrakeStatus|Boolean|false||
 |cloudAppVehicleID|Boolean|false||
+|stabilityControlsStatus|Boolean|false||
 
 ### Response
 
@@ -93,6 +94,7 @@ For vehicle data items from RPCSpec, `oemCustomDataType` will be omitted, and `d
 |engineOilLife|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 |electronicParkBrakeStatus|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 |cloudAppVehicleID|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
+|stabilityControlsStatus|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 
 ### Sequence Diagrams
 

--- a/docs/VehicleInfo/UnsubscribeVehicleData/index.md
+++ b/docs/VehicleInfo/UnsubscribeVehicleData/index.md
@@ -45,6 +45,7 @@ Purpose
 |engineOilLife|Boolean|false||
 |electronicParkBrakeStatus|Boolean|false||
 |cloudAppVehicleID|Boolean|false||
+|stabilityControlsStatus|Boolean|false||
 
 ### Response
 
@@ -94,6 +95,7 @@ For vehicle data items from RPCSpec, `oemCustomDataType` will be omitted, and `d
 |engineOilLife|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 |electronicParkBrakeStatus|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 |cloudAppVehicleID|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
+|stabilityControlsStatus|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 
 ### Sequence Diagrams
 


### PR DESCRIPTION
Guidelines updates according to proposal [SDL-0253](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0253-New-vehicle-data-StabilityControlsStatus.md), issue [#3086](https://github.com/smartdevicelink/sdl_core/issues/3086)

This PR is **ready** for review.

### Summary

1.  Updates for **Common**
* adding new Struct `StabilityControlsStatus`
* extending `VehicleDataType` with new element `VEHICLEDATA_STABILITYCONTROLSSTATUS`

2. Updates in **VehicleInfo**
* adding `stabilityControlsStatus` to request/response params list of the following RPCs:
SubscribeVehicleData
UnsubscribeVehicleData
GetVehicleData
OnVehicleData


### CLA
* [x]  I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)