### PR TITLE
New vehicle data `GearStatus` (outdated)

### DIFF
--- a/docs/Common/Enums/index.md
+++ b/docs/Common/Enums/index.md
@@ -889,6 +889,7 @@
 |VEHICLEDATA_ELECTRONICPARKBRAKESTATUS|29||
 |VEHICLEDATA_CLOUDAPPVEHICLEID|30| Parameter used by cloud apps or the policy server to identify a head unit|
 |VEHICLEDATA_OEM_CUSTOM_DATA|31||
+|VEHICLEDATA_GEARSTATUS|32||
 
 ### VideoStreamingProtocol
 
@@ -936,8 +937,10 @@
 |SIXTH|11||
 |SEVENTH|12||
 |EIGHTH|13||
-|UNKNOWN|14||
-|FAULT|15||
+|NINTH|14||
+|TENTH|15||
+|UNKNOWN|16||
+|FAULT|17||
 
 ### TPMS
 
@@ -1294,3 +1297,16 @@
 |INVALID_TIME|2|When a Service is rejected because the system was unable to get a valid SystemTime from HMI, which is required for certificate authentication.|  
 |PROTECTION_ENFORCED|3|When a Service is rejected because the system configuration ini file requires the service must be protected, but the app asks for an unprotected service.|
 |PROTECTION_DISABLED|4|When a mobile app requests a protected service, but the system starts an unprotected service instead.|
+
+### TransmissionType
+
+|Name|Value|Description|
+|:---|:----|:----------|
+|MANUAL|0|Manual transmission.|
+|AUTOMATIC|1|Automatic transmission.|
+|SEMI_AUTOMATIC|2|Semi automatic transmission.|
+|DUAL_CLUTCH|3|Dual clutch transmission.|
+|CONTINUOUSLY_VARIABLE|4|Continuously variable transmission(CVT).|
+|INFINITELY_VARIABLE|5|Infinitely variable transmission.|
+|ELECTRIC_VARIABLE|6|Electric variable transmission.|
+|DIRECT_DRIVE|7|Direct drive between engine and wheels.|

--- a/docs/Common/Structs/index.md
+++ b/docs/Common/Structs/index.md
@@ -1114,3 +1114,10 @@ There are no defined parameters for this struct.
 |Name|Type|Mandatory|Additional|Description|
 |:---|:---|:--------|:---------|:----------|
 |grid|Common.Grid|false||Describes the location of a seat. HMI shall include this parameter when publishing seat locations in capabilities.|
+
+### GearStatus
+|Name|Type|Mandatory|Additional|Description|
+|:---|:---|:--------|:---------|:----------|
+|userSelectedGear|[Common.PRNDL](../enums/#prndl)|false||Gear position selected by the user<br>i.e. Park, Drive, Reverse|
+|actualGear|[Common.PRNDL](../enums/#prndl)|false||Actual Gear in use by the transmission|
+|transmissionType|[Common.TransmissionType](../enums/#transmissiontype)|false||Tells the transmission type|

--- a/docs/VehicleInfo/GetVehicleData/index.md
+++ b/docs/VehicleInfo/GetVehicleData/index.md
@@ -68,6 +68,7 @@ The HMI will have to update this field if the user chooses to reset this value (
 |engineOilLife|Boolean|false||
 |electronicParkBrakeStatus|Boolean|false||
 |cloudAppVehicleID|Boolean|false||
+|gearStatus|Boolean|false||
 
 ### Response
 
@@ -105,6 +106,7 @@ The HMI will have to update this field if the user chooses to reset this value (
 |engineOilLife|Float|false|minvalue: 0<br>maxvalue: 100|
 |electronicParkBrakeStatus|[Common.ElectronicParkBrakeStatus](../../common/enums/#electronicparkbrakestatus)|false||
 |cloudAppVehicleID|String|false||
+|gearStatus|[Common.GearStatus](../../common/structs/#gearstatus)|false||
 
 ### Sequence Diagrams
 |||

--- a/docs/VehicleInfo/OnVehicleData/index.md
+++ b/docs/VehicleInfo/OnVehicleData/index.md
@@ -61,6 +61,7 @@ The HMI will have to update this field if the user chooses to reset this value (
 |engineOilLife|Float|false|minvalue=0<br>maxvalue=100|
 |electronicParkBrakeStatus|[Common.ElectronicParkBrakeStatus](../../common/enums/#electronicparkbrakestatus)|false||
 |cloudAppVehicleID|String|false||
+|gearStatus|[Common.GearStatus](../../common/structs/#gearstatus)|false||
 
 ### Sequence Diagrams
 |||

--- a/docs/VehicleInfo/SubscribeVehicleData/index.md
+++ b/docs/VehicleInfo/SubscribeVehicleData/index.md
@@ -44,6 +44,7 @@ Purpose
 |engineOilLife|Boolean|false||
 |electronicParkBrakeStatus|Boolean|false||
 |cloudAppVehicleID|Boolean|false||
+|gearStatus|Boolean|false||
 
 ### Response
 !!! must
@@ -92,6 +93,7 @@ For vehicle data items from RPCSpec, `oemCustomDataType` will be omitted, and `d
 |engineOilLife|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 |electronicParkBrakeStatus|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 |cloudAppVehicleID|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
+|gearStatus|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 
 ### Sequence Diagrams
 |||

--- a/docs/VehicleInfo/UnsubscribeVehicleData/index.md
+++ b/docs/VehicleInfo/UnsubscribeVehicleData/index.md
@@ -45,6 +45,7 @@ Purpose
 |engineOilLife|Boolean|false||
 |electronicParkBrakeStatus|Boolean|false||
 |cloudAppVehicleID|Boolean|false||
+|gearStatus|Boolean|false||
 
 ### Response
 !!! must
@@ -92,6 +93,7 @@ For vehicle data items from RPCSpec, `oemCustomDataType` will be omitted, and `d
 |engineOilLife|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 |electronicParkBrakeStatus|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 |cloudAppVehicleID|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
+|gearStatus|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 
 ### Sequence Diagrams
 |||


### PR DESCRIPTION
Guidelines updates according to proposal [SDL-0266](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0266-New-vehicle-data-GearStatus.md)

This PR is **not ready** for review.

### Summary

1.  Updates for **Common**
* extending `VehicleDataType` with new element `VEHICLEDATA_WINDOWSTATUS`
* adding new elements to `PRNDL` enum
* adding new enum `TransmissionType`
* adding new struct `GearStatus`

2. Updates in **VehicleInfo**
* adding `gearStatus` to request/response params list of the following RPCs:
SubscribeVehicleData
UnsubscribeVehicleData
GetVehicleData
OnVehicleData

### CLA
* [x]  I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)s