### PR TITLE
[SDL-0266] Feature/New vehicle data `GearStatus`

### DIFF
--- a/docs/Common/Enums/index.md
+++ b/docs/Common/Enums/index.md
@@ -889,6 +889,7 @@
 |VEHICLEDATA_ELECTRONICPARKBRAKESTATUS|29||
 |VEHICLEDATA_CLOUDAPPVEHICLEID|30| Parameter used by cloud apps or the policy server to identify a head unit|
 |VEHICLEDATA_OEM_CUSTOM_DATA|31||
+|VEHICLEDATA_GEARSTATUS|32||
 
 ### VideoStreamingProtocol
 
@@ -936,8 +937,10 @@
 |SIXTH|11||
 |SEVENTH|12||
 |EIGHTH|13||
-|UNKNOWN|14||
-|FAULT|15||
+|NINTH|14||
+|TENTH|15||
+|UNKNOWN|16||
+|FAULT|17||
 
 ### TPMS
 
@@ -1303,3 +1306,16 @@
 |MOBILE|0||
 |CLOUD|1||
 |BOTH|2||
+
+### TransmissionType
+
+|Name|Value|Description|
+|:---|:----|:----------|
+|MANUAL|0|Manual transmission.|
+|AUTOMATIC|1|Automatic transmission.|
+|SEMI_AUTOMATIC|2|Semi automatic transmission.|
+|DUAL_CLUTCH|3|Dual clutch transmission.|
+|CONTINUOUSLY_VARIABLE|4|Continuously variable transmission(CVT).|
+|INFINITELY_VARIABLE|5|Infinitely variable transmission.|
+|ELECTRIC_VARIABLE|6|Electric variable transmission.|
+|DIRECT_DRIVE|7|Direct drive between engine and wheels.|

--- a/docs/Common/Enums/index.md
+++ b/docs/Common/Enums/index.md
@@ -926,7 +926,7 @@
 |PARK|0|Parking|
 |REVERSE|1|Reverse gear|
 |NEUTRAL|2|No gear|
-|DRIVE|3||
+|DRIVE|3|Regula Drive mode|
 |SPORT|4|Drive Sport mode|
 |LOWGEAR|5|1st gear hold|
 |FIRST|6||

--- a/docs/Common/Structs/index.md
+++ b/docs/Common/Structs/index.md
@@ -1130,3 +1130,11 @@ There are no defined parameters for this struct
 |hybridAppPreference|[Common.HybridAppPreference](../enums/#hybridapppreference)|false||Specifies the user preference to use one specific app type or all available types|
 |endpoint|String|false|maxlength: 65535|If specified, which Core uses a client implementation of the connection type and attempts to connect to the endpoint when this app is selected (activated).<br>If omitted, Core won't attempt to connect as the app selection (activation) is managed outside of Core. Instead it uses a server implementation of the connection type and expects the app to connect|
 
+### GearStatus
+
+|Name|Type|Mandatory|Additional|Description|
+|:---|:---|:--------|:---------|:----------|
+|userSelectedGear|[Common.PRNDL](../enums/#prndl)|false||Gear position selected by the user<br>i.e. Park, Drive, Reverse|
+|actualGear|[Common.PRNDL](../enums/#prndl)|false||Actual Gear in use by the transmission|
+|transmissionType|[Common.TransmissionType](../enums/#transmissiontype)|false||Tells the transmission type|
+

--- a/docs/VehicleInfo/GetVehicleData/index.md
+++ b/docs/VehicleInfo/GetVehicleData/index.md
@@ -70,6 +70,7 @@ The HMI will have to update this field if the user chooses to reset this value (
 |engineOilLife|Boolean|false||
 |electronicParkBrakeStatus|Boolean|false||
 |cloudAppVehicleID|Boolean|false||
+|gearStatus|Boolean|false||
 
 ### Response
 
@@ -107,6 +108,7 @@ The HMI will have to update this field if the user chooses to reset this value (
 |engineOilLife|Float|false|minvalue: 0<br>maxvalue: 100|
 |electronicParkBrakeStatus|[Common.ElectronicParkBrakeStatus](../../common/enums/#electronicparkbrakestatus)|false||
 |cloudAppVehicleID|String|false||
+|gearStatus|[Common.GearStatus](../../common/structs/#gearstatus)|false||
 
 ### Sequence Diagrams
 

--- a/docs/VehicleInfo/OnVehicleData/index.md
+++ b/docs/VehicleInfo/OnVehicleData/index.md
@@ -63,6 +63,7 @@ The HMI will have to update this field if the user chooses to reset this value (
 |engineOilLife|Float|false|minvalue: 0<br>maxvalue: 100|
 |electronicParkBrakeStatus|[Common.ElectronicParkBrakeStatus](../../common/enums/#electronicparkbrakestatus)|false||
 |cloudAppVehicleID|String|false||
+|gearStatus|[Common.GearStatus](../../common/structs/#gearstatus)|false||
 
 ### Sequence Diagrams
 

--- a/docs/VehicleInfo/SubscribeVehicleData/index.md
+++ b/docs/VehicleInfo/SubscribeVehicleData/index.md
@@ -44,6 +44,7 @@ Purpose
 |engineOilLife|Boolean|false||
 |electronicParkBrakeStatus|Boolean|false||
 |cloudAppVehicleID|Boolean|false||
+|gearStatus|Boolean|false||
 
 ### Response
 
@@ -93,6 +94,7 @@ For vehicle data items from RPCSpec, `oemCustomDataType` will be omitted, and `d
 |engineOilLife|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 |electronicParkBrakeStatus|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 |cloudAppVehicleID|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
+|gearStatus|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 
 ### Sequence Diagrams
 

--- a/docs/VehicleInfo/UnsubscribeVehicleData/index.md
+++ b/docs/VehicleInfo/UnsubscribeVehicleData/index.md
@@ -45,6 +45,7 @@ Purpose
 |engineOilLife|Boolean|false||
 |electronicParkBrakeStatus|Boolean|false||
 |cloudAppVehicleID|Boolean|false||
+|gearStatus|Boolean|false||
 
 ### Response
 
@@ -94,6 +95,7 @@ For vehicle data items from RPCSpec, `oemCustomDataType` will be omitted, and `d
 |engineOilLife|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 |electronicParkBrakeStatus|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 |cloudAppVehicleID|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
+|gearStatus|[Common.VehicleDataResult](../../common/structs/#vehicledataresult)|false||
 
 ### Sequence Diagrams
 


### PR DESCRIPTION
Guidelines updates according to issue [#3216](https://github.com/smartdevicelink/sdl_core/issues/3216).

Proposal [SDL-0266](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0266-New-vehicle-data-GearStatus.md)

This PR is **not ready** for review.

### Summary

1.  Updates for **Common**
* extending `VehicleDataType` with new element `VEHICLEDATA_WINDOWSTATUS`
* adding new elements to `PRNDL` enum
* adding new enum `TransmissionType`
* adding new struct `GearStatus`

2. Updates in **VehicleInfo**
* adding `gearStatus` to request/response params list of the following RPCs:
SubscribeVehicleData
UnsubscribeVehicleData
GetVehicleData
OnVehicleData

### CLA
* [x]  I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)s