### PR TITLE
Fix/Media Skip Indicators reset cases

### DIFF
--- a/docs/Common/Enums/index.md
+++ b/docs/Common/Enums/index.md
@@ -136,10 +136,10 @@
 |subtleAlertText1|31|The first line of the subtle alert text field; applies to `SubtleAlert` `alertText1`|
 |subtleAlertText2|32|The second line of the subtle alert text field; applies to `SubtleAlert` `alertText2`|
 |subtleAlertSoftButtonText|33|A text field in the soft button of a subtle alert; applies to `SubtleAlert` `softButtons`|
-|menuCommandSecondaryText|33|Secondary text for AddCommand|
-|menuCommandTertiaryText|34|Tertiary text for AddCommand|
-|menuSubMenuSecondaryText|35|Secondary text for AddSubMenu|
-|menuSubMenuTertiaryText|36|Tertiary text for AddSubMenu|s
+|menuCommandSecondaryText|34|Secondary text for AddCommand|
+|menuCommandTertiaryText|35|Tertiary text for AddCommand|
+|menuSubMenuSecondaryText|36|Secondary text for AddSubMenu|
+|menuSubMenuTertiaryText|37|Tertiary text for AddSubMenu|s
 
 ### MetadataType
 
@@ -1368,6 +1368,7 @@
 |REMOVED|3|The status is selected if a door is physically removed|
 
 ### KeyboardInputMask
+
 |Name|Value|Description|
 |:---|:----|:----------|
 |ENABLE_INPUT_KEY_MASK|0||

--- a/docs/Common/Enums/index.md
+++ b/docs/Common/Enums/index.md
@@ -139,7 +139,7 @@
 |menuCommandSecondaryText|34|Secondary text for AddCommand|
 |menuCommandTertiaryText|35|Tertiary text for AddCommand|
 |menuSubMenuSecondaryText|36|Secondary text for AddSubMenu|
-|menuSubMenuTertiaryText|37|Tertiary text for AddSubMenu|s
+|menuSubMenuTertiaryText|37|Tertiary text for AddSubMenu|
 
 ### MetadataType
 

--- a/docs/Common/Structs/index.md
+++ b/docs/Common/Structs/index.md
@@ -50,7 +50,7 @@
 |diagonalScreenSize|Float|false|minvalue: 0|The diagonal screen size in inches.|
 |pixelPerInch|Float|false|minvalue: 0|PPI is the diagonal resolution in pixels divided by the diagonal screen size in inches.|
 |scale|Float|false|minvalue: 1<br>maxvalue: 10|The scaling factor the app should use to change the size of the projecting view.|
-|preferredFPS|integer|false|minvalue: 0<br>maxvalue: 2147483647|The preferred frame rate per second of the head unit.|
+|preferredFPS|Integer|false|minvalue: 0<br>maxvalue: 2147483647|The preferred frame rate per second of the head unit.|
 |additionalVideoStreamingCapabilities|Common.VideoStreamingCapability|false|array: true<br>minsize: 1<br>maxsize: 100||
 
 ### DynamicUpdateCapabilities
@@ -1112,7 +1112,7 @@ There are no defined parameters for this struct
 |softButtonCapabilities|Common.SoftButtonCapabilities|false|array: true<br>minsize: 1<br>maxsize: 100|The number of soft buttons available on-window and the capabilities for each button.|
 |menuLayoutsAvailable|[Common.MenuLayout](../enums/#menulayout)|false|array: true<br>minsize: 1<br>maxsize: 1000|An array of available menu layouts. If this parameter is not provided, only the `LIST` layout is assumed to be available|
 |dynamicUpdateCapabilities|Common.DynamicUpdateCapabilities|false||Contains the head unit's capabilities for dynamic updating features declaring if the module will send dynamic update RPCs|
-|keyboardCapabilities|[Common.KeyboardCapabilities](../structs/#keyboardcapabilities)|false||See KeyboardCapabilities|
+|keyboardCapabilities|Common.KeyboardCapabilities|false||See KeyboardCapabilities|
 
 ### ModuleInfo
 
@@ -1239,7 +1239,7 @@ There are no defined parameters for this struct
 |:---|:---|:--------|:---------|:----------|
 |externalTemperature|Common.Temperature|false||The external temperature in degrees celsius|
 |cabinTemperature|Common.Temperature|false||Internal ambient cabin temperature in degrees celsius|
-|atmosphericPressure|float|false|minvalue: 0<br>maxvalue: 2000|Current atmospheric pressure in mBar|
+|atmosphericPressure|Float|false|minvalue: 0<br>maxvalue: 2000|Current atmospheric pressure in mBar|
 
 ### KeyboardCapabilities
 

--- a/docs/UI/SetGlobalProperties/index.md
+++ b/docs/UI/SetGlobalProperties/index.md
@@ -84,7 +84,7 @@ In case HMI does not respond to SDL Core request during SDL-default timeout (10 
 
 #### Parameters
 
-This RPC has no additional parameter requirements.
+This RPC has no additional parameter requirements
 
 ### Sequence Diagrams
 

--- a/docs/UI/SetMediaClockTimer/index.md
+++ b/docs/UI/SetMediaClockTimer/index.md
@@ -40,6 +40,14 @@ The UI.SetMediaClockTimer request indicates either an initial value for the medi
 3. Initially, the appID together with other application-related information is provided by SDL within one of _UpdateAppList_ and _OnAppRegistered_ RPCs.   
 !!!
 
+!!! NOTE
+By default the seek indicators should be `TRACK` when:
+
+- The media app is newly registered on the head unit (after `RegisterAppInterface` and the button subscription).
+- The media app was closed by the user (App enters HMI level `NONE`).
+- The app sends a `SetMediaClockTimer` request with `forwardSeekIndicator` and/or `backSeekIndicator` not set to any value. 
+!!!
+
 #### Parameters
 
 |Name|Type|Mandatory|Additional|Description|

--- a/docs/UI/SetMediaClockTimer/index.md
+++ b/docs/UI/SetMediaClockTimer/index.md
@@ -41,7 +41,7 @@ The UI.SetMediaClockTimer request indicates either an initial value for the medi
 !!!
 
 !!! NOTE
-By default the seek indicators should be `TRACK` when:
+By default, `forwardSeekIndicator` and `backSeekIndicator` should be set to `TRACK`. The HMI should reset these values to `TRACK` when:
 
 - The media app is newly registered on the head unit (after `RegisterAppInterface` and the button subscription).
 - The media app was closed by the user (App enters HMI level `NONE`).

--- a/docs/VehicleInfo/GetVehicleData/index.md
+++ b/docs/VehicleInfo/GetVehicleData/index.md
@@ -136,7 +136,7 @@ The HMI will have to update this field if the user chooses to reset this value (
 |stabilityControlsStatus|[Common.StabilityControlsStatus](../../common/structs/#stabilitycontrolsstatus)|false||
 |windowStatus|[Common.WindowStatus](../../common/structs/#windowstatus)|false|array: true<br>minsize: 0<br>maxsize: 100|
 |handsOffSteering|Boolean|false||
-|seatOccupancy|[Common.SeatOccupancy](../../common/structs/#seatoccupancy)|false|
+|seatOccupancy|[Common.SeatOccupancy](../../common/structs/#seatoccupancy)|false||
 |climateData|[Common.ClimateData](../../common/structs/#climatedata)|false||
 
 ### Sequence Diagrams


### PR DESCRIPTION
Add note for cases where the media skip indicators are reset to `TRACK` (https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0198-media-skip-indicators.md#proposed-solution)


>By default the seek indicators should be TRACK when:
>
> - The media app is newly registered on the head unit (after RegisterAppInterface and the button subscription)
> - The media app was closed by the user (App enters HMI_NONE)
> - The app sends SetMediaClockTimer with forwardSeekIndicator and / or backSeekIndicator not set to any value.


